### PR TITLE
Silver shimmer for agent thinking indicator

### DIFF
--- a/src/components/agent-panel.tsx
+++ b/src/components/agent-panel.tsx
@@ -95,18 +95,7 @@ function hasAssistantOutput(message: UIMessage) {
 function AgentThinking({ label = 'Thinking' }: { label?: string }) {
   return (
     <p className="cx-agent-thinking w-fit text-sm" role="status" aria-label={`${label}…`}>
-      <span aria-hidden="true">
-        {[...label].map((character, index) => (
-          <span
-            key={`${character}-${index}`}
-            data-char
-            style={{ '--cx-char-index': index } as React.CSSProperties}
-          >
-            {character}
-          </span>
-        ))}
-        <span className="cx-agent-thinking-dots">…</span>
-      </span>
+      <span aria-hidden="true">{label}…</span>
     </p>
   )
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -204,29 +204,30 @@ body {
   animation: cx-shimmer 1.4s ease-in-out infinite;
 }
 
-.cx-agent-thinking [data-char] {
-  display: inline-block;
-  color: var(--color-muted-foreground);
-  opacity: 0.42;
-  animation: cx-agent-thinking 1.25s ease-in-out infinite;
-  animation-delay: calc(var(--cx-char-index) * 55ms);
-}
-
-.cx-agent-thinking-dots {
-  color: var(--color-muted-foreground);
-  opacity: 0.55;
+.cx-agent-thinking {
+  background-image: linear-gradient(
+    105deg,
+    #6a6761 0%,
+    #6a6761 38%,
+    #9e9b94 45%,
+    #e8e6e1 50%,
+    #9e9b94 55%,
+    #6a6761 62%,
+    #6a6761 100%
+  );
+  background-size: 220% 100%;
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+  animation: cx-agent-thinking 1.8s linear infinite;
 }
 
 @keyframes cx-agent-thinking {
-  0%,
-  55%,
-  100% {
-    color: var(--color-muted-foreground);
-    opacity: 0.42;
+  0% {
+    background-position: 100% 0;
   }
-  24% {
-    color: var(--foreground);
-    opacity: 1;
+  100% {
+    background-position: -100% 0;
   }
 }
 
@@ -247,9 +248,12 @@ body {
     color: var(--color-muted-foreground);
   }
 
-  .cx-agent-thinking [data-char] {
+  .cx-agent-thinking {
     animation: none;
-    opacity: 1;
+    background-image: none;
+    background-clip: unset;
+    -webkit-background-clip: unset;
+    color: var(--color-muted-foreground);
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Replace the per-character opacity pulse on “Thinking” / “Reasoning” with a sliding silver gradient text shimmer.

### Changes
- Simplify `AgentThinking` to a single text node (no per-letter spans)
- Animate a cool metallic gradient via `background-clip: text`
- Keep `prefers-reduced-motion` as a static muted label

### Why
The old wave felt like a blink cascade rather than a shimmer. The silver sheen reads clearer as an AI “thinking” state and matches common chat UI patterns.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7718-4ef7-7472-ab7e-e14e4747de32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7718-4ef7-7472-ab7e-e14e4747de32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

