### PR TITLE
Fix buggy silver thinking shimmer

### DIFF
--- a/src/components/agent-panel.tsx
+++ b/src/components/agent-panel.tsx
@@ -93,9 +93,12 @@ function hasAssistantOutput(message: UIMessage) {
 }
 
 function AgentThinking({ label = 'Thinking' }: { label?: string }) {
+  const text = `${label}…`
   return (
-    <p className="cx-agent-thinking w-fit text-sm" role="status" aria-label={`${label}…`}>
-      <span aria-hidden="true">{label}…</span>
+    <p className="w-fit text-sm" role="status" aria-label={text}>
+      <span className="cx-agent-thinking" aria-hidden="true">
+        {text}
+      </span>
     </p>
   )
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -205,29 +205,31 @@ body {
 }
 
 .cx-agent-thinking {
+  display: inline-block;
   background-image: linear-gradient(
-    105deg,
-    #6a6761 0%,
-    #6a6761 38%,
-    #9e9b94 45%,
-    #e8e6e1 50%,
-    #9e9b94 55%,
-    #6a6761 62%,
-    #6a6761 100%
+    90deg,
+    #6e6b65 0%,
+    #6e6b65 35%,
+    #bdbab3 45%,
+    #f4f3ef 50%,
+    #bdbab3 55%,
+    #6e6b65 65%,
+    #6e6b65 100%
   );
-  background-size: 220% 100%;
+  background-size: 200% 100%;
   background-clip: text;
   -webkit-background-clip: text;
   color: transparent;
-  animation: cx-agent-thinking 1.8s linear infinite;
+  -webkit-text-fill-color: transparent;
+  animation: cx-agent-thinking 1.5s linear infinite;
 }
 
 @keyframes cx-agent-thinking {
-  0% {
-    background-position: 100% 0;
+  from {
+    background-position: 200% 0;
   }
-  100% {
-    background-position: -100% 0;
+  to {
+    background-position: -200% 0;
   }
 }
 
@@ -254,6 +256,7 @@ body {
     background-clip: unset;
     -webkit-background-clip: unset;
     color: var(--color-muted-foreground);
+    -webkit-text-fill-color: var(--color-muted-foreground);
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the silver thinking shimmer after #1 — it could look broken or flicker because the gradient was clipped on the parent while the text lived in a child span.

### Fixes
- Apply `.cx-agent-thinking` on the text span so `background-clip: text` targets real glyphs
- Set `-webkit-text-fill-color: transparent` for consistent rendering
- Use a seamless `200% → -200%` background-position loop
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7718-4ef7-7472-ab7e-e14e4747de32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7718-4ef7-7472-ab7e-e14e4747de32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

