### PR TITLE
fix(db): tolerate existing design revision

### DIFF
--- a/packages/db/drizzle/0026_slow_hellfire_club.sql
+++ b/packages/db/drizzle/0026_slow_hellfire_club.sql
@@ -20,7 +20,7 @@ CREATE TABLE "design_draft" (
 --> statement-breakpoint
 DROP INDEX "design_chat_design_idx";--> statement-breakpoint
 DROP INDEX "design_version_design_idx";--> statement-breakpoint
-ALTER TABLE "design" ADD COLUMN "revision" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "design" ADD COLUMN IF NOT EXISTS "revision" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
 ALTER TABLE "design_chat" ADD COLUMN "draft_id" text;--> statement-breakpoint
 ALTER TABLE "design_version" ADD COLUMN "draft_id" text;--> statement-breakpoint
 ALTER TABLE "design_draft" ADD CONSTRAINT "design_draft_design_fk" FOREIGN KEY ("design_id","user_id") REFERENCES "public"."design"("id","user_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint


### PR DESCRIPTION
## What changed

- Make migration `0026_slow_hellfire_club` tolerate an existing `design.revision` column with `ADD COLUMN IF NOT EXISTS`.

## Why

Production had already recorded an earlier migration that created `design.revision`. Migration 0026 attempted to create it again, causing `drizzle-kit migrate` to exit before the web server could start and Railway to mark the deployment as crashed.

## Impact

The draft-schema migration can reconcile the existing production database state without failing. The repaired source was deployed to Railway and the migration completed successfully.

## Validation

- `bun run test` — 303 passing
- `bunx tsc --noEmit`
- `bun run build`
- Railway deployment `bb1c53b2-981c-41e0-ac79-41d312ac1a1f` — `SUCCESS`
- `https://loora.design/` — `200`
- unauthenticated `POST /api/chat` — expected `401`