### PR TITLE
feat(api): move backend to Hono service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,11 @@ REALTIME_INTERNAL_TOKEN=replace-with-at-least-32-random-characters
 # Optional comma-separated browser origins allowed to open a socket.
 REALTIME_ALLOWED_ORIGINS=http://localhost:3000
 BETTER_AUTH_SECRET=replace-with-at-least-32-random-characters
-BETTER_AUTH_URL=http://localhost:3000
+# Public API origin used by Better Auth when it creates callback URLs.
+BETTER_AUTH_URL=http://localhost:3001
+# Browser app origin and credentialed CORS allowlist for the standalone API.
+APP_ORIGIN=http://localhost:3000
+API_ALLOWED_ORIGINS=http://localhost:3000,https://loora.design
 REQUIRE_PREVIEW_ACCESS=true
 REQUIRE_POLAR_BILLING=false
 POLAR_SERVER=production
@@ -89,13 +93,13 @@ MCP_SCREENSHOT_QUEUE_TIMEOUT_MS=20000
 MCP_SCREENSHOT_IDLE_TIMEOUT_MS=60000
 MCP_AUTH_TIMEOUT_MS=5000
 MCP_INTERNAL_TOKEN=replace-with-a-distinct-at-least-32-character-secret
-# Optional private web-service URL; defaults to BETTER_AUTH_URL/api/internal/mcp.
+# Optional private API-service URL; defaults to BETTER_AUTH_URL/api/internal/mcp.
 MCP_INTERNAL_API_URL=
-# Opt-in JSON request timing logs for web/MCP (`api.request` console.info lines).
+# Opt-in JSON request timing logs for web/API/MCP (`api.request` console.info lines).
 LOG_REQUEST_TIMING=false
 # Local authenticated API benchmark. Keep credential values out of commits.
 LOORA_BENCHMARK_TARGET=canvas
-LOORA_BENCHMARK_BASE_URL=http://localhost:3000
+LOORA_BENCHMARK_BASE_URL=http://localhost:3001
 LOORA_BENCHMARK_DESIGN_ID=
 LOORA_BENCHMARK_DRAFT_ID=
 LOORA_BENCHMARK_SESSION_COOKIE=

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 # Workspace manifests only, so dependency layers cache until a package.json,
 # the lockfile, or bunfig (isolated linker config) changes.
 COPY package.json bun.lock bunfig.toml ./
+COPY apps/api/package.json apps/api/
 COPY apps/desktop/package.json apps/desktop/
 COPY apps/web/package.json apps/web/
 COPY packages/db/package.json packages/db/
@@ -96,4 +97,4 @@ EXPOSE 3000
 # --smol trades GC frequency for a smaller heap; CPU sits near zero in
 # production so the tradeoff is free memory.
 ENTRYPOINT ["/usr/bin/tini", "--"]
-CMD ["sh", "-c", "bun run --cwd packages/db migrate:deploy && exec bun --smol run apps/web/.output/server/index.mjs"]
+CMD ["bun", "--smol", "run", "apps/web/.output/server/index.mjs"]

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,49 @@
+# syntax=docker/dockerfile:1
+
+FROM oven/bun:1.3.14 AS deps
+WORKDIR /app
+
+COPY package.json bun.lock bunfig.toml ./
+COPY apps/api/package.json apps/api/
+COPY apps/desktop/package.json apps/desktop/
+COPY apps/web/package.json apps/web/
+COPY packages/db/package.json packages/db/
+COPY packages/auth/package.json packages/auth/
+COPY packages/email/package.json packages/email/
+COPY packages/billing/package.json packages/billing/
+COPY packages/agent/package.json packages/agent/
+COPY packages/canvas/package.json packages/canvas/
+COPY packages/platform/package.json packages/platform/
+COPY packages/shell/package.json packages/shell/
+COPY packages/realtime/package.json packages/realtime/
+COPY packages/rpc/package.json packages/rpc/
+COPY packages/railway/package.json packages/railway/
+COPY packages/editor/package.json packages/editor/
+COPY packages/ui/package.json packages/ui/
+RUN bun install --frozen-lockfile
+
+FROM oven/bun:1.3.14-slim AS runtime
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV HOST=0.0.0.0
+ENV PORT=3001
+ENV PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium
+
+USER root
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends chromium fonts-liberation tini \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/apps ./apps
+COPY --from=deps /app/packages ./packages
+COPY package.json bun.lock bunfig.toml tsconfig.json ./
+COPY apps/api ./apps/api
+COPY packages ./packages
+
+USER bun
+EXPOSE 3001
+ENTRYPOINT ["/usr/bin/tini", "--"]
+# The API service is the sole deploy-time migration owner.
+CMD ["sh", "-c", "bun run --cwd packages/db migrate:deploy && exec bun --smol run apps/api/src/index.ts"]

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@loora/api",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "bun --env-file=../../.env --watch run src/index.ts",
+    "start": "bun --env-file=../../.env run src/index.ts",
+    "typecheck": "bunx tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@loora/auth": "workspace:*",
+    "@loora/billing": "workspace:*",
+    "@loora/db": "workspace:*",
+    "@loora/realtime": "workspace:*",
+    "@loora/rpc": "workspace:*",
+    "@orpc/server": "^1.14.8",
+    "drizzle-orm": "catalog:",
+    "hono": "^4.9.6"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.14",
+    "typescript": "catalog:"
+  }
+}

--- a/apps/api/railway.json
+++ b/apps/api/railway.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "apps/api/Dockerfile",
+    "watchPatterns": [
+      "apps/api/**",
+      "packages/**",
+      "package.json",
+      "bun.lock",
+      "bunfig.toml",
+      "tsconfig.json",
+      "apps/api/railway.json"
+    ]
+  },
+  "deploy": {
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 5,
+    "sleepApplication": false,
+    "healthcheckPath": "/api/ready"
+  }
+}

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'vitest'
+import { app } from './index'
+
+describe('API routing', () => {
+  test('allows credentialed requests from the web app', async () => {
+    const response = await app.request('/api/rpc/design.list', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'http://localhost:3000',
+        'Access-Control-Request-Method': 'POST',
+      },
+    })
+
+    expect(response.status).toBe(204)
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe(
+      'http://localhost:3000',
+    )
+    expect(response.headers.get('Access-Control-Allow-Credentials')).toBe('true')
+  })
+
+  test('keeps handoff capability URLs available to arbitrary origins', async () => {
+    const response = await app.request('/api/handoff/token', {
+      method: 'OPTIONS',
+      headers: { Origin: 'https://agent.example' },
+    })
+
+    expect(response.status).toBe(204)
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*')
+  })
+
+  test('does not proxy unknown API routes to the web service', async () => {
+    const response = await app.request('/api/not-a-route')
+
+    expect(response.status).toBe(404)
+  })
+})

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,0 +1,221 @@
+import { onError } from '@orpc/server'
+import { RPCHandler } from '@orpc/server/fetch'
+import { auth, getSession, mcpOAuthDiscoveryHandler } from '@loora/auth'
+import { checkDatabaseConnection } from '@loora/db'
+import {
+  canUseApp,
+  isPreviewProtectedAuthPath,
+  previewAccessRequiredResponse,
+} from '@loora/auth/preview-access'
+import {
+  hasAcceptedCurrentLegal,
+  isLegalProtectedAuthPath,
+  legalConsentRequiredResponse,
+} from '@loora/auth/legal-consent'
+import { requireMcpConsent } from '@loora/auth/mcp-consent'
+import { appRouter } from '@loora/rpc'
+import { serviceReadinessResponse } from '@loora/rpc/readiness'
+import {
+  elapsedMilliseconds,
+  logRequestTiming,
+  requestIdFromHeaders,
+  withRequestTimingHeaders,
+} from '@loora/rpc/request-timing'
+import {
+  callerIdentity,
+  clientAddress,
+  rateLimit,
+  rateLimits,
+  tooManyRequestsResponse,
+  UNKNOWN_ADDRESS,
+} from '@loora/rpc/rate-limit'
+import { Hono } from 'hono'
+import { cors } from 'hono/cors'
+import { handleAssetRequest } from './routes/asset'
+import { canvasEventsResponse } from './routes/api.canvas-events'
+import { canvasPresenceResponse } from './routes/api.canvas-presence'
+import { realtimeTicketResponse } from './routes/api.realtime-ticket'
+import {
+  handleCustomDomainSiteHeadRequest,
+  handleCustomDomainSiteRequest,
+} from './routes/custom-domain-site'
+import { handleCustomDomainSyncRequest } from './routes/custom-domain-sync'
+import { handleGitHubCallback } from './routes/github-callback'
+import { handleGitHubConnect } from './routes/github-connect'
+import { handleGitHubInstall } from './routes/github-install'
+import { handleGitHubSetup } from './routes/github-setup'
+import { handleGitHubWebhook } from './routes/github-webhook'
+import { handleHandoffAssetRequest } from './routes/handoff-asset'
+import {
+  handleHandoffOptionsRequest,
+  handleHandoffRequest,
+} from './routes/handoff'
+import { handleInternalMcpRequest } from './routes/internal-mcp'
+
+const DEFAULT_ALLOWED_ORIGINS = ['http://localhost:3000', 'https://loora.design']
+
+function commaSeparated(value: string | undefined) {
+  return value?.split(',').map((entry) => entry.trim()).filter(Boolean) ?? []
+}
+
+const configuredAllowedOrigins = commaSeparated(process.env.API_ALLOWED_ORIGINS)
+const allowedOrigins = new Set(
+  configuredAllowedOrigins.length > 0
+    ? configuredAllowedOrigins
+    : DEFAULT_ALLOWED_ORIGINS,
+)
+
+const rpcHandler = new RPCHandler(appRouter, {
+  interceptors: [onError((error) => console.error('[orpc]', error))],
+})
+
+const CREDENTIAL_PATHS = [
+  '/sign-in/email',
+  '/sign-in/username',
+  '/sign-up/email',
+  '/forget-password',
+  '/reset-password',
+  '/change-password',
+  '/change-email',
+  '/send-verification-email',
+  '/two-factor/verify-totp',
+  '/two-factor/verify-otp',
+  '/email-otp/send-verification-otp',
+  '/email-otp/verify-email',
+  '/one-time-token/verify',
+]
+
+function isCredentialPath(pathname: string) {
+  return CREDENTIAL_PATHS.some((path) => pathname.endsWith(path))
+}
+
+async function handleRpc(request: Request) {
+  const startedAt = performance.now()
+  const requestId = requestIdFromHeaders(request.headers)
+  const sessionStartedAt = performance.now()
+  const session = await getSession(request)
+  const sessionMs = elapsedMilliseconds(sessionStartedAt)
+  const userId = session?.user?.id ?? null
+  const decision = await rateLimit(
+    userId ? 'rpc' : 'rpc-anonymous',
+    callerIdentity(request.headers, userId),
+    userId ? rateLimits.rpc : rateLimits.rpcAnonymous,
+  )
+  if (!decision.ok) return tooManyRequestsResponse(decision)
+
+  const handlerStartedAt = performance.now()
+  const { response } = await rpcHandler.handle(request, {
+    prefix: '/api/rpc',
+    context: { session },
+  })
+  const handlerMs = elapsedMilliseconds(handlerStartedAt)
+  const resolved = response ?? new Response('Not Found', { status: 404 })
+  const totalMs = elapsedMilliseconds(startedAt)
+  logRequestTiming({
+    service: 'api',
+    requestId,
+    method: request.method,
+    path: new URL(request.url).pathname,
+    status: resolved.status,
+    durationMs: totalMs,
+    phases: { session: sessionMs, handler: handlerMs },
+  })
+
+  return withRequestTimingHeaders(resolved, requestId, [
+    { name: 'session', durationMs: sessionMs },
+    { name: 'handler', durationMs: handlerMs },
+    { name: 'total', durationMs: totalMs },
+  ])
+}
+
+async function handleAuth(request: Request) {
+  const pathname = new URL(request.url).pathname
+  const address = clientAddress(request.headers)
+  const credential = isCredentialPath(pathname) && address !== UNKNOWN_ADDRESS
+  const decision = await rateLimit(
+    credential ? 'auth-credentials' : 'auth',
+    `ip:${address}`,
+    credential ? rateLimits.authSensitive : rateLimits.auth,
+  )
+  if (!decision.ok) {
+    return tooManyRequestsResponse(
+      decision,
+      'Too many attempts. Wait a moment and try again.',
+    )
+  }
+
+  if (isLegalProtectedAuthPath(pathname) || isPreviewProtectedAuthPath(pathname)) {
+    const session = await getSession(request)
+    if (
+      session &&
+      isLegalProtectedAuthPath(pathname) &&
+      !hasAcceptedCurrentLegal(session.user)
+    ) {
+      return legalConsentRequiredResponse()
+    }
+    if (session && !canUseApp(session.user)) return previewAccessRequiredResponse()
+  }
+
+  // Returning Better Auth's Fetch Response directly preserves every Set-Cookie header.
+  return auth.handler(requireMcpConsent(request))
+}
+
+const app = new Hono()
+
+// Handoff payloads are capability URLs consumed by arbitrary agent origins.
+app.options('/api/handoff/:token', (context) =>
+  handleHandoffOptionsRequest(context.req.raw),
+)
+app.get('/api/handoff/:token', (context) =>
+  handleHandoffRequest(context.req.raw, context.req.param('token')),
+)
+app.get('/api/handoff/:token/asset/:id', (context) =>
+  handleHandoffAssetRequest(
+    context.req.raw,
+    context.req.param('token'),
+    context.req.param('id'),
+  ),
+)
+
+app.use('/api/*', cors({
+  origin: (origin) => allowedOrigins.has(origin) ? origin : undefined,
+  credentials: true,
+}))
+
+app.get('/api/ready', () => serviceReadinessResponse('api', checkDatabaseConnection))
+app.get('/.well-known/oauth-authorization-server', (context) =>
+  mcpOAuthDiscoveryHandler(context.req.raw),
+)
+app.all('/api/rpc/*', (context) => handleRpc(context.req.raw))
+app.on(['GET', 'POST'], '/api/auth/*', (context) => handleAuth(context.req.raw))
+app.get('/api/asset/:id', (context) =>
+  handleAssetRequest(context.req.raw, context.req.param('id')),
+)
+app.post('/api/realtime-ticket', (context) => realtimeTicketResponse(context.req.raw))
+app.get('/api/canvas-events', (context) => canvasEventsResponse(context.req.raw))
+app.post('/api/canvas-presence', (context) => canvasPresenceResponse(context.req.raw))
+app.get('/api/github/connect', (context) => handleGitHubConnect(context.req.raw))
+app.get('/api/github/callback', (context) => handleGitHubCallback(context.req.raw))
+app.get('/api/github/install', (context) => handleGitHubInstall(context.req.raw))
+app.get('/api/github/setup', (context) => handleGitHubSetup(context.req.raw))
+app.post('/api/github/webhook', (context) => handleGitHubWebhook(context.req.raw))
+app.post('/api/internal/mcp', (context) => handleInternalMcpRequest(context.req.raw))
+app.post('/api/internal/custom-domain-sync', (context) =>
+  handleCustomDomainSyncRequest(context.req.raw),
+)
+app.get('/api/custom-domain-site', (context) =>
+  handleCustomDomainSiteRequest(context.req.raw),
+)
+app.on('HEAD', '/api/custom-domain-site', (context) =>
+  handleCustomDomainSiteHeadRequest(context.req.raw),
+)
+
+const port = Number(process.env.PORT || 3001)
+
+export { app }
+
+export default {
+  port,
+  hostname: process.env.HOST || '0.0.0.0',
+  fetch: app.fetch,
+}

--- a/apps/api/src/routes/-realtime-access.ts
+++ b/apps/api/src/routes/-realtime-access.ts
@@ -1,0 +1,133 @@
+import { and, eq } from 'drizzle-orm'
+import { requireSession } from '@loora/auth'
+import {
+  canUseApp,
+  previewAccessRequiredResponse,
+} from '@loora/auth/preview-access'
+import {
+  hasAcceptedCurrentLegal,
+  legalConsentRequiredResponse,
+} from '@loora/auth/legal-consent'
+import {
+  authorizeBilling,
+  subscriptionRequiredResponse,
+} from '@loora/billing/billing'
+import { db } from '@loora/db'
+import { resolveDesignAccess } from '@loora/db/design-access'
+import { designDraft } from '@loora/db/schema'
+
+/**
+ * The one gate in front of realtime, shared by the WebSocket ticket endpoint
+ * and the server-sent-events fallback. Both transports must agree on who may
+ * watch a document; keeping the checks in one place is what makes that true.
+ */
+
+export type RealtimeSession = NonNullable<Awaited<ReturnType<typeof requireSession>>>
+
+export interface RealtimeAccess {
+  session: RealtimeSession
+  ownerUserId: string
+  role: 'owner' | 'edit' | 'view'
+  designId: string
+  draftId: string | null
+}
+
+export type RealtimeAccessResult =
+  | { ok: true; access: RealtimeAccess }
+  | { ok: false; response: Response }
+
+export type RealtimeSessionResult =
+  | { ok: true; session: RealtimeSession }
+  | { ok: false; response: Response }
+
+/**
+ * Who is asking, before anything is looked up on their behalf. Split out from
+ * the access check so a caller can turn away a flood of requests from one
+ * account without paying for a design lookup per attempt.
+ */
+export async function requireRealtimeSession(
+  request: Request,
+): Promise<RealtimeSessionResult> {
+  const session = await requireSession(request)
+  if (!session) {
+    return { ok: false, response: new Response('Unauthorized', { status: 401 }) }
+  }
+  if (!hasAcceptedCurrentLegal(session.user)) {
+    return { ok: false, response: legalConsentRequiredResponse() }
+  }
+  return { ok: true, session }
+}
+
+function draftExists(ownerUserId: string, designId: string, draftId: string) {
+  return db
+    .select({ id: designDraft.id })
+    .from(designDraft)
+    .where(
+      and(
+        eq(designDraft.id, draftId),
+        eq(designDraft.designId, designId),
+        eq(designDraft.userId, ownerUserId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => !!rows[0])
+}
+
+export async function resolveRealtimeAccess(
+  request: Request,
+  input: { designId: string; draftId: string | null },
+): Promise<RealtimeAccessResult> {
+  const authenticated = await requireRealtimeSession(request)
+  if (!authenticated.ok) return authenticated
+  return resolveRealtimeAccessForSession(authenticated.session, input)
+}
+
+export async function resolveRealtimeAccessForSession(
+  session: RealtimeSession,
+  input: { designId: string; draftId: string | null },
+): Promise<RealtimeAccessResult> {
+  const designId = input.designId.trim()
+  const draftId = input.draftId?.trim() || null
+  if (
+    designId.length === 0 ||
+    designId.length > 128 ||
+    (draftId !== null && draftId.length > 128)
+  ) {
+    return {
+      ok: false,
+      response: new Response('Invalid Canvas target', { status: 400 }),
+    }
+  }
+
+  const access = await resolveDesignAccess(designId, {
+    id: session.user.id,
+    email: session.user.email,
+  })
+  if (!access) {
+    return { ok: false, response: new Response('Not found', { status: 404 }) }
+  }
+  // Owners are held to their own plan; a guest in a shared design rides the
+  // owner's, which is what makes an invitation worth anything.
+  if (access.role === 'owner') {
+    if (!canUseApp(session.user)) {
+      return { ok: false, response: previewAccessRequiredResponse() }
+    }
+    if (!(await authorizeBilling(session.user)).access) {
+      return { ok: false, response: subscriptionRequiredResponse() }
+    }
+  }
+  if (draftId && !(await draftExists(access.ownerUserId, designId, draftId))) {
+    return { ok: false, response: new Response('Not found', { status: 404 }) }
+  }
+
+  return {
+    ok: true,
+    access: {
+      session,
+      ownerUserId: access.ownerUserId,
+      role: access.role,
+      designId,
+      draftId,
+    },
+  }
+}

--- a/apps/api/src/routes/api.canvas-events.ts
+++ b/apps/api/src/routes/api.canvas-events.ts
@@ -1,0 +1,161 @@
+import {
+  readCanvasAgentActivity,
+  readCanvasPresence,
+  subscribeCanvasRealtimeEvents,
+  type CanvasRealtimeEvent,
+  type CanvasRealtimeSubscription,
+} from '@loora/db/canvas-realtime'
+import {
+  rateLimit,
+  rateLimits,
+  tooManyRequestsResponse,
+} from '@loora/rpc/rate-limit'
+import {
+  requireRealtimeSession,
+  resolveRealtimeAccessForSession,
+} from './-realtime-access'
+
+const encoder = new TextEncoder()
+const eventHeaders = {
+  'Cache-Control': 'no-cache, no-transform',
+  'Content-Type': 'text/event-stream; charset=utf-8',
+  Connection: 'keep-alive',
+  'X-Accel-Buffering': 'no',
+  'X-Content-Type-Options': 'nosniff',
+}
+
+function eventData(event: CanvasRealtimeEvent) {
+  return `event: canvas\ndata: ${JSON.stringify(event)}\n\n`
+}
+
+export async function canvasEventsResponse(request: Request) {
+  const search = new URL(request.url).searchParams
+  const authenticated = await requireRealtimeSession(request)
+  if (!authenticated.ok) return authenticated.response
+  // Counted before the design lookup: a client reconnecting in a loop should
+  // cost this instance a counter increment, not a round of access checks and
+  // a subscription.
+  const decision = await rateLimit(
+    'canvas-events',
+    `user:${authenticated.session.user.id}`,
+    rateLimits.canvasEvents,
+  )
+  if (!decision.ok) {
+    return tooManyRequestsResponse(decision, 'Too many event stream connections')
+  }
+  const resolved = await resolveRealtimeAccessForSession(authenticated.session, {
+    designId: search.get('designId') ?? '',
+    draftId: search.get('draftId'),
+  })
+  if (!resolved.ok) return resolved.response
+  const { ownerUserId, designId, draftId } = resolved.access
+
+  const pending: CanvasRealtimeEvent[] = []
+  let streamController: ReadableStreamDefaultController<Uint8Array> | null =
+    null
+  let heartbeat: ReturnType<typeof setInterval> | null = null
+  let subscription: CanvasRealtimeSubscription | null = null
+  let cleaned = false
+  let transportClosed = false
+
+  const push = (event: CanvasRealtimeEvent) => {
+    if (!streamController) {
+      pending.push(event)
+      return
+    }
+    try {
+      streamController.enqueue(encoder.encode(eventData(event)))
+    } catch {
+      cleanup()
+    }
+  }
+  const closeStream = () => {
+    transportClosed = true
+    if (!streamController) return
+    try {
+      streamController.close()
+    } catch {
+      // The browser may have already cancelled the stream.
+    }
+  }
+  const cleanup = () => {
+    if (cleaned) return
+    cleaned = true
+    if (heartbeat) clearInterval(heartbeat)
+    request.signal.removeEventListener('abort', onAbort)
+    subscription?.close()
+  }
+  const onAbort = () => {
+    cleanup()
+    closeStream()
+  }
+
+  try {
+    subscription = await subscribeCanvasRealtimeEvents(
+      ownerUserId,
+      { designId, draftId },
+      push,
+      () => {
+        cleanup()
+        closeStream()
+      },
+    )
+  } catch {
+    console.error('[canvas-realtime] Could not open event stream')
+    return new Response('Realtime Canvas events are unavailable', {
+      status: 503,
+      headers: { 'Retry-After': '10' },
+    })
+  }
+  if (!subscription) {
+    return new Response('Realtime Canvas events are not configured', {
+      status: 503,
+      headers: { 'Retry-After': '30' },
+    })
+  }
+
+  request.signal.addEventListener('abort', onAbort, { once: true })
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      streamController = controller
+      if (transportClosed) {
+        controller.close()
+        return
+      }
+      controller.enqueue(
+        encoder.encode('retry: 5000\nevent: ready\ndata: {}\n\n'),
+      )
+      // Whoever is already in the room, so a late arrival sees them without
+      // waiting for each of them to move.
+      void readCanvasPresence(ownerUserId, { designId, draftId })
+        .then((peers) => {
+          if (peers.length > 0) {
+            push({ type: 'presence.state', peers, sentAt: Date.now() })
+          }
+        })
+        .catch(() => undefined)
+      // Same for an agent that is already mid-run: the tab shows it now rather
+      // than at its next tool call.
+      void readCanvasAgentActivity(ownerUserId, { designId, draftId })
+        .then((activity) => {
+          if (activity) {
+            push({ type: 'agent.activity', activity, sentAt: Date.now() })
+          }
+        })
+        .catch(() => undefined)
+      for (const event of pending.splice(0)) push(event)
+      heartbeat = setInterval(() => {
+        try {
+          controller.enqueue(encoder.encode(': keepalive\n\n'))
+        } catch {
+          cleanup()
+        }
+      }, 15_000)
+    },
+    cancel() {
+      cleanup()
+    },
+  })
+
+  return new Response(stream, { headers: eventHeaders })
+}

--- a/apps/api/src/routes/api.canvas-presence.ts
+++ b/apps/api/src/routes/api.canvas-presence.ts
@@ -1,0 +1,107 @@
+import { requireSession } from '@loora/auth'
+import {
+  hasAcceptedCurrentLegal,
+  legalConsentRequiredResponse,
+} from '@loora/auth/legal-consent'
+import {
+  clearCanvasPresence,
+  presenceColor,
+  publishCanvasPresence,
+} from '@loora/db/canvas-realtime'
+import { resolveDesignAccess } from '@loora/db/design-access'
+import {
+  normalizePresenceInput,
+  scopePresenceSessionId,
+} from '@loora/realtime/events'
+import {
+  rateLimit,
+  rateLimits,
+  tooManyRequestsResponse,
+} from '@loora/rpc/rate-limit'
+
+function record(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+/**
+ * The fallback presence path, used only when a client cannot hold a socket.
+ *
+ * A client reports only where it is, never who it is. Identity, colour and role
+ * are stamped from the session here, so a peer cannot publish itself as someone
+ * else or promote itself to an editor in the face pile — and the key it
+ * occupies in the room is scoped to the account, so one person can only ever
+ * overwrite their own tabs.
+ */
+export async function canvasPresenceResponse(request: Request) {
+  const session = await requireSession(request)
+  if (!session) return new Response('Unauthorized', { status: 401 })
+  if (!hasAcceptedCurrentLegal(session.user)) return legalConsentRequiredResponse()
+
+  // Presence is decoration: a dropped frame costs a stale cursor, so the
+  // ceiling can sit well above what a pointer that never stops sends.
+  const decision = await rateLimit(
+    'canvas-presence',
+    `user:${session.user.id}`,
+    rateLimits.canvasPresence,
+  )
+  if (!decision.ok) return tooManyRequestsResponse(decision, 'Too much presence traffic')
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return new Response('Invalid presence payload', { status: 400 })
+  }
+  if (!record(body)) return new Response('Invalid presence payload', { status: 400 })
+
+  const designId = typeof body.designId === 'string' ? body.designId.trim() : ''
+  const draftId =
+    typeof body.draftId === 'string' && body.draftId.trim()
+      ? body.draftId.trim()
+      : null
+  const clientId = typeof body.sessionId === 'string' ? body.sessionId : ''
+  if (
+    designId.length === 0 ||
+    designId.length > 128 ||
+    (draftId !== null && draftId.length > 128) ||
+    clientId.length === 0 ||
+    clientId.length > 128
+  ) {
+    return new Response('Invalid presence payload', { status: 400 })
+  }
+  const sessionId = scopePresenceSessionId(session.user.id, clientId)
+
+  const access = await resolveDesignAccess(designId, {
+    id: session.user.id,
+    email: session.user.email,
+  })
+  if (!access) return new Response('Not found', { status: 404 })
+
+  const target = { designId, draftId }
+  if (body.leaving === true) {
+    await clearCanvasPresence(access.ownerUserId, target, sessionId)
+    return new Response(null, { status: 204 })
+  }
+
+  const { cursor, selection } = normalizePresenceInput(body) ?? {
+    cursor: null,
+    selection: [],
+  }
+
+  const published = await publishCanvasPresence(access.ownerUserId, target, {
+    sessionId,
+    userId: session.user.id,
+    name: session.user.name || session.user.email,
+    image: session.user.image ?? null,
+    color: presenceColor(session.user.id),
+    role: access.role,
+    cursor,
+    selection,
+    updatedAt: Date.now(),
+  })
+  // The caller is told which key it ended up under so it can recognise its own
+  // frames coming back through the event stream.
+  return published
+    ? Response.json({ sessionId }, { headers: { 'Cache-Control': 'no-store' } })
+    : new Response('Presence is unavailable', { status: 503 })
+}

--- a/apps/api/src/routes/api.realtime-ticket.ts
+++ b/apps/api/src/routes/api.realtime-ticket.ts
@@ -1,0 +1,112 @@
+import { presenceColor } from '@loora/realtime/events'
+import {
+  REALTIME_TICKET_TTL_MS,
+  signRealtimeTicket,
+} from '@loora/realtime/ticket'
+import {
+  rateLimit,
+  rateLimits,
+  tooManyRequestsResponse,
+} from '@loora/rpc/rate-limit'
+import {
+  requireRealtimeSession,
+  resolveRealtimeAccessForSession,
+} from './-realtime-access'
+
+/**
+ * Mints a connection ticket for the WebSocket service.
+ *
+ * `ws.loora.design` is its own origin, so the browser cannot send it the
+ * session cookie. This endpoint runs every check the editor already runs —
+ * session, legal consent, design access, preview access, plan — and hands back
+ * a signed, short-lived ticket that carries the identity the room should show.
+ * A 503 here is not an error: it means realtime is not configured, and the
+ * client quietly falls back to the server-sent-events stream.
+ */
+
+function record(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+/**
+ * Minting a ticket costs a design lookup, a plan check, and a branch check, so
+ * an account that asks in a loop should be turned away before any of that. One
+ * socket needs a ticket every 15 minutes plus a few on reconnects; the limit
+ * leaves room for a bad network without leaving room for a script.
+ */
+export function allowTicketRequest(userId: string) {
+  return rateLimit('realtime-ticket', `user:${userId}`, rateLimits.realtimeTicket)
+}
+
+function realtimeConfig() {
+  const url = process.env.REALTIME_WS_URL?.trim()
+  const secret = process.env.REALTIME_TICKET_SECRET?.trim()
+  if (!url || !secret) return null
+  return { url: url.replace(/\/+$/, ''), secret }
+}
+
+export async function realtimeTicketResponse(request: Request) {
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return new Response('Invalid ticket request', { status: 400 })
+  }
+  if (!record(body)) {
+    return new Response('Invalid ticket request', { status: 400 })
+  }
+
+  const authenticated = await requireRealtimeSession(request)
+  if (!authenticated.ok) return authenticated.response
+  const decision = await allowTicketRequest(authenticated.session.user.id)
+  if (!decision.ok) {
+    return tooManyRequestsResponse(decision, 'Too many ticket requests')
+  }
+
+  const resolved = await resolveRealtimeAccessForSession(authenticated.session, {
+    designId: typeof body.designId === 'string' ? body.designId : '',
+    draftId: typeof body.draftId === 'string' ? body.draftId : null,
+  })
+  if (!resolved.ok) return resolved.response
+
+  const config = realtimeConfig()
+  if (!config) {
+    return Response.json(
+      { configured: false },
+      { status: 503, headers: { 'Retry-After': '300' } },
+    )
+  }
+
+  const { session, ownerUserId, role, designId, draftId } = resolved.access
+  // The room key is minted here rather than taken from the caller. A client
+  // that chose it could claim a peer's key and overwrite — or on disconnect,
+  // clear — somebody else's cursor.
+  const sessionId = crypto.randomUUID()
+  const issuedAt = Date.now()
+  const expiresAt = issuedAt + REALTIME_TICKET_TTL_MS
+  const ticket = await signRealtimeTicket(
+    {
+      v: 1,
+      // Spent on first use by the socket service, so a ticket that leaks is
+      // worth at most the one connection it was minted for.
+      jti: crypto.randomUUID(),
+      userId: session.user.id,
+      sessionId,
+      ownerUserId,
+      designId,
+      draftId,
+      role,
+      name: session.user.name || session.user.email,
+      image: session.user.image ?? null,
+      color: presenceColor(session.user.id),
+      issuedAt,
+      expiresAt,
+    },
+    config.secret,
+  )
+
+  return Response.json(
+    { url: `${config.url}/canvas`, ticket, sessionId, expiresAt },
+    { headers: { 'Cache-Control': 'no-store' } },
+  )
+}

--- a/apps/api/src/routes/asset.ts
+++ b/apps/api/src/routes/asset.ts
@@ -1,0 +1,56 @@
+import { and, eq } from 'drizzle-orm'
+import { requireSession } from '@loora/auth'
+import {
+  hasAcceptedCurrentLegal,
+  legalConsentRequiredResponse,
+} from '@loora/auth/legal-consent'
+import { canUseApp, previewAccessRequiredResponse } from '@loora/auth/preview-access'
+import { authorizeBilling, subscriptionRequiredResponse } from '@loora/billing/billing'
+import { db } from '@loora/db'
+import { asset } from '@loora/db/schema'
+import {
+  rateLimit,
+  rateLimits,
+  tooManyRequestsResponse,
+} from '@loora/rpc/rate-limit'
+import { s3 } from '@loora/rpc/storage'
+
+export async function handleAssetRequest(request: Request, id: string) {
+  const session = await requireSession(request)
+  if (!session) return new Response('Unauthorized', { status: 401 })
+
+  const decision = await rateLimit(
+    'asset',
+    `user:${session.user.id}`,
+    rateLimits.asset,
+  )
+  if (!decision.ok) return tooManyRequestsResponse(decision)
+
+  if (!hasAcceptedCurrentLegal(session.user)) return legalConsentRequiredResponse()
+  if (!canUseApp(session.user)) return previewAccessRequiredResponse()
+  if (!(await authorizeBilling(session.user)).access) return subscriptionRequiredResponse()
+
+  const [found] = await db
+    .select({ data: asset.data, storageKey: asset.storageKey, mediaType: asset.mediaType })
+    .from(asset)
+    .where(and(eq(asset.id, id), eq(asset.userId, session.user.id)))
+    .limit(1)
+
+  if (!found) return new Response('Not found', { status: 404 })
+
+  let bytes: Uint8Array
+  if (found.storageKey && s3) {
+    bytes = new Uint8Array(await s3.file(found.storageKey).arrayBuffer())
+  } else if (found.data) {
+    bytes = Uint8Array.from(atob(found.data), (character) => character.charCodeAt(0))
+  } else {
+    return new Response('Asset payload unavailable', { status: 500 })
+  }
+
+  return new Response(new Blob([bytes as Uint8Array<ArrayBuffer>]), {
+    headers: {
+      'Content-Type': found.mediaType,
+      'Cache-Control': 'private, max-age=31536000, immutable',
+    },
+  })
+}

--- a/apps/api/src/routes/custom-domain-site.ts
+++ b/apps/api/src/routes/custom-domain-site.ts
@@ -1,0 +1,62 @@
+import { loadPublishedSiteHtmlByDomain } from '@loora/rpc/publish-procedures'
+import { callerIdentity, rateLimit, rateLimits } from '@loora/rpc/rate-limit'
+
+const responseHeaders = {
+  'Content-Type': 'text/html; charset=utf-8',
+  'Cache-Control': 'no-store',
+  'Referrer-Policy': 'no-referrer',
+  'X-Content-Type-Options': 'nosniff',
+}
+
+export function forwardedCustomDomain(headers: Headers) {
+  if (headers.get('x-loora-custom-domain') !== 'true') return null
+  const raw = headers.get('x-forwarded-host')?.split(',').at(-1)?.trim()
+  if (!raw) return null
+  try {
+    return new URL(`https://${raw}`).hostname.toLowerCase()
+  } catch {
+    return null
+  }
+}
+
+export async function handleCustomDomainSiteRequest(request: Request) {
+  const domain = forwardedCustomDomain(request.headers)
+  if (!domain) {
+    return new Response('Published site not found.', {
+      status: 404,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    })
+  }
+
+  const decision = await rateLimit(
+    'publishedSite',
+    callerIdentity(request.headers),
+    rateLimits.publishedSite,
+  )
+  if (!decision.ok) {
+    return new Response('Too many requests. Try again shortly.', {
+      status: 429,
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'Retry-After': String(decision.retryAfterSeconds),
+      },
+    })
+  }
+
+  const site = await loadPublishedSiteHtmlByDomain(domain)
+  if (!site) {
+    return new Response('Published site not found.', {
+      status: 404,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    })
+  }
+  return new Response(site.html, { status: 200, headers: responseHeaders })
+}
+
+export async function handleCustomDomainSiteHeadRequest(request: Request) {
+  const response = await handleCustomDomainSiteRequest(request)
+  return new Response(null, {
+    status: response.status,
+    headers: response.headers,
+  })
+}

--- a/apps/api/src/routes/custom-domain-sync.ts
+++ b/apps/api/src/routes/custom-domain-sync.ts
@@ -1,0 +1,24 @@
+import { timingSafeEqual } from 'node:crypto'
+import { syncPublishedSiteDomains } from '@loora/rpc/publish-domain-sync'
+
+function authorized(request: Request) {
+  const configured = process.env.CUSTOM_DOMAIN_SYNC_TOKEN?.trim()
+  const supplied =
+    request.headers.get('authorization')?.replace(/^Bearer /, '') ?? ''
+  if (!configured) return false
+  const expected = Buffer.from(configured)
+  const actual = Buffer.from(supplied)
+  return expected.length === actual.length && timingSafeEqual(expected, actual)
+}
+
+export async function handleCustomDomainSyncRequest(request: Request) {
+  if (!authorized(request)) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const result = await syncPublishedSiteDomains()
+  return Response.json(result, {
+    status: result.enabled && !result.configured ? 503 : 200,
+    headers: { 'Cache-Control': 'no-store' },
+  })
+}

--- a/apps/api/src/routes/github-callback.ts
+++ b/apps/api/src/routes/github-callback.ts
@@ -1,0 +1,82 @@
+import { requireSession } from '@loora/auth'
+import {
+  clearGitHubFlowCookie,
+  exchangeGitHubCode,
+  getGitHubUser,
+  githubFlowCookie,
+  saveGitHubAccount,
+  syncGitHubInstallations,
+  verifyGitHubFlow,
+} from '@loora/auth/github'
+import {
+  hasAcceptedCurrentLegal,
+  legalConsentRequiredResponse,
+} from '@loora/auth/legal-consent'
+import { canUseApp, previewAccessRequiredResponse } from '@loora/auth/preview-access'
+import { authorizeBilling, subscriptionRequiredResponse } from '@loora/billing/billing'
+import {
+  callerIdentity,
+  rateLimit,
+  rateLimits,
+  tooManyRequestsResponse,
+} from '@loora/rpc/rate-limit'
+
+const appOrigin = process.env.APP_ORIGIN?.trim().replace(/\/+$/, '') || 'http://localhost:3000'
+
+function redirect(result: string, cookie?: string) {
+  const headers: Record<string, string> = {
+    Location: new URL(
+      `/app/integrations?integration=github&github=${result}`,
+      appOrigin,
+    ).toString(),
+  }
+  if (cookie) headers['Set-Cookie'] = cookie
+  return new Response(null, { status: 302, headers })
+}
+
+export async function handleGitHubCallback(request: Request) {
+  const decision = await rateLimit(
+    'github',
+    callerIdentity(request.headers),
+    rateLimits.github,
+  )
+  if (!decision.ok) return tooManyRequestsResponse(decision)
+
+  const session = await requireSession(request)
+  if (!session) return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  if (!hasAcceptedCurrentLegal(session.user)) return legalConsentRequiredResponse()
+  if (!canUseApp(session.user)) return previewAccessRequiredResponse()
+  if (!(await authorizeBilling(session.user)).access) return subscriptionRequiredResponse()
+
+  const url = new URL(request.url)
+  if (url.searchParams.get('error')) {
+    return redirect('cancelled', clearGitHubFlowCookie(githubFlowCookie.oauth))
+  }
+  try {
+    const flow = await verifyGitHubFlow(
+      request.headers.get('cookie'),
+      githubFlowCookie.oauth,
+      'oauth',
+      url.searchParams.get('state'),
+      session.user.id,
+    )
+    const code = url.searchParams.get('code')
+    if (!code || !flow.verifier) throw new Error('Missing GitHub code')
+    const tokens = await exchangeGitHubCode(code, flow.verifier)
+    const profile = await getGitHubUser(tokens.accessToken)
+    await saveGitHubAccount(session.user.id, profile, tokens)
+    const installations = await syncGitHubInstallations(session.user.id)
+    if (installations.length === 0) {
+      return new Response(null, {
+        status: 302,
+        headers: {
+          Location: new URL('/api/github/install', request.url).toString(),
+          'Set-Cookie': clearGitHubFlowCookie(githubFlowCookie.oauth),
+        },
+      })
+    }
+    return redirect('connected', clearGitHubFlowCookie(githubFlowCookie.oauth))
+  } catch {
+    return redirect('failed', clearGitHubFlowCookie(githubFlowCookie.oauth))
+  }
+}

--- a/apps/api/src/routes/github-connect.ts
+++ b/apps/api/src/routes/github-connect.ts
@@ -1,0 +1,44 @@
+import { requireSession } from '@loora/auth'
+import { createGitHubOAuthFlow } from '@loora/auth/github'
+import {
+  hasAcceptedCurrentLegal,
+  legalConsentRequiredResponse,
+} from '@loora/auth/legal-consent'
+import { canUseApp, previewAccessRequiredResponse } from '@loora/auth/preview-access'
+import { authorizeBilling, subscriptionRequiredResponse } from '@loora/billing/billing'
+import {
+  callerIdentity,
+  rateLimit,
+  rateLimits,
+  tooManyRequestsResponse,
+} from '@loora/rpc/rate-limit'
+
+const appOrigin = process.env.APP_ORIGIN?.trim().replace(/\/+$/, '') || 'http://localhost:3000'
+
+export async function handleGitHubConnect(request: Request) {
+  const decision = await rateLimit(
+    'github',
+    callerIdentity(request.headers),
+    rateLimits.github,
+  )
+  if (!decision.ok) return tooManyRequestsResponse(decision)
+
+  const session = await requireSession(request)
+  if (!session) return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  if (!hasAcceptedCurrentLegal(session.user)) return legalConsentRequiredResponse()
+  if (!canUseApp(session.user)) return previewAccessRequiredResponse()
+  if (!(await authorizeBilling(session.user)).access) return subscriptionRequiredResponse()
+
+  try {
+    const flow = await createGitHubOAuthFlow(session.user.id)
+    return new Response(null, {
+      status: 302,
+      headers: { Location: flow.url, 'Set-Cookie': flow.cookie },
+    })
+  } catch {
+    return Response.redirect(
+      new URL('/app/integrations?integration=github&github=unavailable', appOrigin),
+      302,
+    )
+  }
+}

--- a/apps/api/src/routes/github-install.ts
+++ b/apps/api/src/routes/github-install.ts
@@ -1,0 +1,48 @@
+import { requireSession } from '@loora/auth'
+import { createGitHubInstallFlow, getGitHubStatus } from '@loora/auth/github'
+import {
+  hasAcceptedCurrentLegal,
+  legalConsentRequiredResponse,
+} from '@loora/auth/legal-consent'
+import { canUseApp, previewAccessRequiredResponse } from '@loora/auth/preview-access'
+import { authorizeBilling, subscriptionRequiredResponse } from '@loora/billing/billing'
+import {
+  callerIdentity,
+  rateLimit,
+  rateLimits,
+  tooManyRequestsResponse,
+} from '@loora/rpc/rate-limit'
+
+const appOrigin = process.env.APP_ORIGIN?.trim().replace(/\/+$/, '') || 'http://localhost:3000'
+
+export async function handleGitHubInstall(request: Request) {
+  const decision = await rateLimit(
+    'github',
+    callerIdentity(request.headers),
+    rateLimits.github,
+  )
+  if (!decision.ok) return tooManyRequestsResponse(decision)
+
+  const session = await requireSession(request)
+  if (!session) return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  if (!hasAcceptedCurrentLegal(session.user)) return legalConsentRequiredResponse()
+  if (!canUseApp(session.user)) return previewAccessRequiredResponse()
+  if (!(await authorizeBilling(session.user)).access) return subscriptionRequiredResponse()
+
+  const status = await getGitHubStatus(session.user.id)
+  if (!status.connected) {
+    return Response.redirect(new URL('/api/github/connect', request.url), 302)
+  }
+  try {
+    const flow = await createGitHubInstallFlow(session.user.id)
+    return new Response(null, {
+      status: 302,
+      headers: { Location: flow.url, 'Set-Cookie': flow.cookie },
+    })
+  } catch {
+    return Response.redirect(
+      new URL('/app/integrations?integration=github&github=failed', appOrigin),
+      302,
+    )
+  }
+}

--- a/apps/api/src/routes/github-setup.ts
+++ b/apps/api/src/routes/github-setup.ts
@@ -1,0 +1,73 @@
+import { requireSession } from '@loora/auth'
+import {
+  clearGitHubFlowCookie,
+  githubFlowCookie,
+  syncGitHubInstallations,
+  verifyGitHubFlow,
+} from '@loora/auth/github'
+import {
+  hasAcceptedCurrentLegal,
+  legalConsentRequiredResponse,
+} from '@loora/auth/legal-consent'
+import { canUseApp, previewAccessRequiredResponse } from '@loora/auth/preview-access'
+import { authorizeBilling, subscriptionRequiredResponse } from '@loora/billing/billing'
+import {
+  callerIdentity,
+  rateLimit,
+  rateLimits,
+  tooManyRequestsResponse,
+} from '@loora/rpc/rate-limit'
+
+const appOrigin = process.env.APP_ORIGIN?.trim().replace(/\/+$/, '') || 'http://localhost:3000'
+
+function finish(result: string) {
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: new URL(
+        `/app/integrations?integration=github&github=${result}`,
+        appOrigin,
+      ).toString(),
+      'Set-Cookie': clearGitHubFlowCookie(githubFlowCookie.install),
+    },
+  })
+}
+
+export async function handleGitHubSetup(request: Request) {
+  const decision = await rateLimit(
+    'github',
+    callerIdentity(request.headers),
+    rateLimits.github,
+  )
+  if (!decision.ok) return tooManyRequestsResponse(decision)
+
+  const session = await requireSession(request)
+  if (!session) return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  if (!hasAcceptedCurrentLegal(session.user)) return legalConsentRequiredResponse()
+  if (!canUseApp(session.user)) return previewAccessRequiredResponse()
+  if (!(await authorizeBilling(session.user)).access) return subscriptionRequiredResponse()
+
+  const url = new URL(request.url)
+  try {
+    // GitHub preserves state for Loora-initiated installs. A direct
+    // installation update may omit it, so user-token ownership remains final.
+    if (url.searchParams.has('state')) {
+      await verifyGitHubFlow(
+        request.headers.get('cookie'),
+        githubFlowCookie.install,
+        'install',
+        url.searchParams.get('state'),
+        session.user.id,
+      )
+    }
+    const installationId = url.searchParams.get('installation_id')
+    if (!installationId) throw new Error('Missing installation')
+    const installations = await syncGitHubInstallations(session.user.id)
+    if (!installations.some((installation) => String(installation.id) === installationId)) {
+      throw new Error('Installation does not belong to user')
+    }
+    return finish('connected')
+  } catch {
+    return finish('failed')
+  }
+}

--- a/apps/api/src/routes/github-webhook.ts
+++ b/apps/api/src/routes/github-webhook.ts
@@ -1,0 +1,34 @@
+import {
+  githubEnabled,
+  processGitHubWebhook,
+  verifyGitHubWebhook,
+} from '@loora/auth/github'
+import {
+  callerIdentity,
+  rateLimit,
+  rateLimits,
+  tooManyRequestsResponse,
+} from '@loora/rpc/rate-limit'
+
+export async function handleGitHubWebhook(request: Request) {
+  if (!githubEnabled) return new Response('Not found', { status: 404 })
+  // Deliveries are signed, so this only limits unsigned noise before verification.
+  const decision = await rateLimit(
+    'github-webhook',
+    callerIdentity(request.headers),
+    rateLimits.githubWebhook,
+  )
+  if (!decision.ok) return tooManyRequestsResponse(decision)
+
+  const rawBody = await request.text()
+  if (!await verifyGitHubWebhook(rawBody, request.headers.get('x-hub-signature-256'))) {
+    return new Response('Invalid signature', { status: 401 })
+  }
+  try {
+    const payload = JSON.parse(rawBody) as Record<string, unknown>
+    await processGitHubWebhook(request.headers.get('x-github-event') ?? '', payload)
+    return new Response(null, { status: 204 })
+  } catch {
+    return new Response('Invalid payload', { status: 400 })
+  }
+}

--- a/apps/api/src/routes/handoff-asset.ts
+++ b/apps/api/src/routes/handoff-asset.ts
@@ -1,0 +1,66 @@
+import { and, eq } from 'drizzle-orm'
+import { db } from '@loora/db'
+import { asset } from '@loora/db/schema'
+import { getHandoffDesign, referencedAssetIds } from '@loora/rpc/handoff'
+import {
+  callerIdentity,
+  rateLimit,
+  rateLimits,
+  tooManyRequestsResponse,
+} from '@loora/rpc/rate-limit'
+import { s3 } from '@loora/rpc/storage'
+
+export async function handleHandoffAssetRequest(
+  request: Request,
+  token: string,
+  id: string,
+) {
+  const decision = await rateLimit(
+    'handoff-asset',
+    callerIdentity(request.headers),
+    rateLimits.handoff,
+  )
+  if (!decision.ok) return tooManyRequestsResponse(decision)
+
+  const handoff = await getHandoffDesign(token)
+  if (
+    !handoff ||
+    !referencedAssetIds(handoff.document ?? handoff.shapes).has(id)
+  ) {
+    return new Response('Not found', { status: 404 })
+  }
+
+  const [found] = await db
+    .select({
+      data: asset.data,
+      storageKey: asset.storageKey,
+      mediaType: asset.mediaType,
+      name: asset.name,
+    })
+    .from(asset)
+    .where(and(eq(asset.id, id), eq(asset.userId, handoff.userId)))
+    .limit(1)
+  if (!found) return new Response('Not found', { status: 404 })
+
+  let bytes: Uint8Array
+  if (found.storageKey && s3) {
+    bytes = new Uint8Array(await s3.file(found.storageKey).arrayBuffer())
+  } else if (found.data) {
+    bytes = Uint8Array.from(atob(found.data), (character) => character.charCodeAt(0))
+  } else {
+    return new Response('Asset unavailable', { status: 404 })
+  }
+
+  const filename = found.name.replace(/["\\\r\n]/g, '_')
+  return new Response(new Blob([bytes as Uint8Array<ArrayBuffer>]), {
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Cache-Control': 'no-store',
+      'Content-Disposition': `attachment; filename="${filename}"`,
+      'Content-Security-Policy': "sandbox; default-src 'none'",
+      'Content-Type': found.mediaType,
+      'Referrer-Policy': 'no-referrer',
+      'X-Content-Type-Options': 'nosniff',
+    },
+  })
+}

--- a/apps/api/src/routes/handoff.ts
+++ b/apps/api/src/routes/handoff.ts
@@ -1,0 +1,43 @@
+import { buildHandoffPayload } from '@loora/rpc/handoff'
+import { callerIdentity, rateLimit, rateLimits } from '@loora/rpc/rate-limit'
+
+const publicHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Cache-Control': 'no-store',
+  'Content-Type': 'application/json; charset=utf-8',
+  'Referrer-Policy': 'no-referrer',
+  'X-Content-Type-Options': 'nosniff',
+}
+
+export async function handleHandoffRequest(request: Request, token: string) {
+  const decision = await rateLimit(
+    'handoff',
+    callerIdentity(request.headers),
+    rateLimits.handoff,
+  )
+  if (!decision.ok) {
+    return new Response(
+      JSON.stringify({ error: 'Too many requests. Try again shortly.' }),
+      {
+        status: 429,
+        headers: {
+          ...publicHeaders,
+          'Retry-After': String(decision.retryAfterSeconds),
+        },
+      },
+    )
+  }
+
+  const payload = await buildHandoffPayload(token, new URL(request.url).origin)
+  if (!payload) {
+    return Response.json(
+      { error: 'Handoff not found or expired.' },
+      { status: 404, headers: publicHeaders },
+    )
+  }
+  return Response.json(payload, { headers: publicHeaders })
+}
+
+export function handleHandoffOptionsRequest(_request: Request) {
+  return new Response(null, { status: 204, headers: publicHeaders })
+}

--- a/apps/api/src/routes/internal-mcp.ts
+++ b/apps/api/src/routes/internal-mcp.ts
@@ -1,0 +1,78 @@
+import { timingSafeEqual } from 'node:crypto'
+import { db, checkDatabaseConnection } from '@loora/db'
+import { createLooraToolExecutor } from '@loora/rpc/mcp-server'
+import { AccessDeniedError, requireAppAccess } from '@loora/rpc/mcp-access'
+import { createMcpUsageController } from '@loora/rpc/mcp-usage'
+
+type InternalRequest =
+  | { action: 'ready' }
+  | { action: 'access'; userId: string }
+  | { action: 'execute'; userId: string; tool: string; arguments?: unknown }
+  | { action: 'resolveUser'; selector: string }
+
+function authorized(request: Request) {
+  const configured = process.env.MCP_INTERNAL_TOKEN?.trim()
+  const supplied = request.headers.get('authorization')?.replace(/^Bearer /, '') ?? ''
+  if (!configured) return false
+  const expected = Buffer.from(configured)
+  const actual = Buffer.from(supplied)
+  return expected.length === actual.length && timingSafeEqual(expected, actual)
+}
+
+async function resolveUser(selector: string) {
+  const found = await db.query.user.findFirst({
+    columns: { id: true, email: true },
+    where: (account, { eq, or }) =>
+      or(eq(account.id, selector), eq(account.email, selector)),
+  })
+  if (!found) throw new Error(`LOORA_MCP_USER did not match a user: ${selector}`)
+  return found
+}
+
+export async function handleInternalMcpRequest(request: Request) {
+  if (!authorized(request)) return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  let input: InternalRequest
+  try {
+    input = await request.json() as InternalRequest
+  } catch {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  try {
+    if (input.action === 'ready') {
+      await checkDatabaseConnection()
+      return Response.json({ ready: true }, { headers: { 'Cache-Control': 'no-store' } })
+    }
+    if (input.action === 'resolveUser') {
+      const account = await resolveUser(input.selector.trim())
+      await requireAppAccess(account.id)
+      return Response.json(account, { headers: { 'Cache-Control': 'no-store' } })
+    }
+    if (input.action === 'access') {
+      await requireAppAccess(input.userId)
+      return Response.json({ allowed: true }, { headers: { 'Cache-Control': 'no-store' } })
+    }
+    if (input.action === 'execute') {
+      const access = await requireAppAccess(input.userId)
+      const execute = createLooraToolExecutor(
+        input.userId,
+        createMcpUsageController(input.userId, access.mcpPlan, access.mcpUsageOptions),
+        async () => (await requireAppAccess(input.userId)).mcpPlan,
+      )
+      return Response.json(
+        await execute(input.tool, input.arguments ?? {}),
+        { headers: { 'Cache-Control': 'no-store' } },
+      )
+    }
+    return Response.json({ error: 'Unknown action' }, { status: 400 })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Internal MCP request failed'
+    return Response.json(
+      { error: message },
+      {
+        status: error instanceof AccessDeniedError ? 403 : 400,
+        headers: { 'Cache-Control': 'no-store' },
+      },
+    )
+  }
+}

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*.ts"]
+}

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -17,7 +17,7 @@ bun run build:desktop   # Vite interface + native Tauri bundle
 **The host** (`src-tauri/`) runs under Rust. It serves a loopback HTTP
 server, opens the window on it, and is the only thing that ever holds the
 session. Everything the window asks for under `/api/*` is forwarded to
-loora.design with `Authorization: Bearer <session token>` attached, which is
+api.loora.design with `Authorization: Bearer <session token>` attached, which is
 why the window needs no cookie, no CORS, and no credential of its own:
 `/api/asset/…` images, the server-sent event stream, and oRPC all behave
 exactly as they do on the web.
@@ -73,7 +73,8 @@ window controls never overlap the editor's top-left canvas controls.
 
 | Variable | Meaning |
 |----------|---------|
-| `LOORA_API_ORIGIN` | Deployment to talk to (default `https://loora.design`) |
+| `LOORA_API_ORIGIN` | API deployment to talk to (default `https://api.loora.design`) |
+| `LOORA_APP_ORIGIN` | Public app origin used for browser sign-in and trusted-origin headers (default `https://loora.design`) |
 | `LOORA_DESKTOP_PORT` | Loopback port for the host (default: one the OS picks; `4300` in development) |
 | `LOORA_DESKTOP_DEV_SERVER` | Vite dev server the window is handed to |
 | `LOORA_DESKTOP_APP_PORT` | Port for that dev server (default `1421`) |

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -50,6 +50,7 @@ const KEYRING_ACCOUNT: &str = "session";
 #[derive(Clone)]
 struct Config {
     api_origin: Url,
+    app_origin: Url,
     dev_server: Option<Url>,
     app_root: PathBuf,
 }
@@ -84,7 +85,8 @@ struct OpenRequest {
 
 impl Config {
     fn read(app: &tauri::AppHandle) -> Self {
-        let api_origin = read_origin("LOORA_API_ORIGIN", "https://loora.design");
+        let api_origin = read_origin("LOORA_API_ORIGIN", "https://api.loora.design");
+        let app_origin = read_origin("LOORA_APP_ORIGIN", "https://loora.design");
         let dev_server = env::var("LOORA_DESKTOP_DEV_SERVER")
             .ok()
             .filter(|value| !value.trim().is_empty())
@@ -104,6 +106,7 @@ impl Config {
 
         Self {
             api_origin,
+            app_origin,
             dev_server,
             app_root,
         }
@@ -242,7 +245,7 @@ async fn desktop_sign_in(State(state): State<AppState>) -> Response {
     *state.pending_state.write().await = Some(pending.clone());
     let mut target = state
         .config
-        .api_origin
+        .app_origin
         .join("/desktop/auth")
         .expect("valid desktop auth URL");
     target
@@ -291,8 +294,9 @@ async fn callback(State(state): State<AppState>, request: Request) -> Response {
         .post(target)
         .header(
             ORIGIN.as_str(),
-            state.config.api_origin.as_str().trim_end_matches('/'),
+            state.config.app_origin.as_str().trim_end_matches('/'),
         )
+        .header(REFERER.as_str(), state.config.app_origin.as_str())
         .json(&json!({ "token": token.unwrap() }))
         .send()
         .await;
@@ -338,8 +342,9 @@ async fn desktop_sign_out(State(state): State<AppState>) -> Response {
             .bearer_auth(token)
             .header(
                 ORIGIN.as_str(),
-                state.config.api_origin.as_str().trim_end_matches('/'),
+                state.config.app_origin.as_str().trim_end_matches('/'),
             )
+            .header(REFERER.as_str(), state.config.app_origin.as_str())
             .json(&json!({}))
             .send()
             .await;
@@ -421,9 +426,9 @@ async fn proxy_api(State(state): State<AppState>, request: Request) -> Response 
     upstream = upstream
         .header(
             ORIGIN.as_str(),
-            state.config.api_origin.as_str().trim_end_matches('/'),
+            state.config.app_origin.as_str().trim_end_matches('/'),
         )
-        .header(REFERER.as_str(), state.config.api_origin.as_str());
+        .header(REFERER.as_str(), state.config.app_origin.as_str());
     if let Some(token) = state.session.get().await {
         upstream = upstream.bearer_auth(token);
     }
@@ -565,7 +570,7 @@ async fn realtime(
     let Some(upstream) = upstream else {
         return (StatusCode::SERVICE_UNAVAILABLE, "No realtime target yet").into_response();
     };
-    let origin = state.config.api_origin.to_string();
+    let origin = state.config.app_origin.to_string();
     ws.protocols([REALTIME_PROTOCOL])
         .on_upgrade(move |socket| bridge_realtime(socket, upstream, protocols, origin))
 }

--- a/apps/web/src/platform.ts
+++ b/apps/web/src/platform.ts
@@ -1,0 +1,7 @@
+import { configureRuntime } from '@loora/platform'
+
+configureRuntime({
+  apiOrigin:
+    import.meta.env.VITE_LOORA_API_ORIGIN ??
+    (import.meta.env.DEV ? 'http://localhost:3001' : 'https://api.loora.design'),
+})

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,3 +1,6 @@
+// Runtime configuration must run before the route tree imports auth and RPC clients.
+import './platform'
+
 import { createRouter as createTanStackRouter } from '@tanstack/react-router'
 import { routeTree } from './routeTree.gen'
 

--- a/apps/web/src/routes/-api.asset.test.ts
+++ b/apps/web/src/routes/-api.asset.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'vitest'
+import { apiAssetUrl } from './api.asset.$id'
+
+describe('asset API compatibility route', () => {
+  test('sends production asset requests to the API service', () => {
+    expect(
+      apiAssetUrl(
+        new Request('https://loora.design/api/asset/asset-id'),
+        'asset-id',
+      ).toString(),
+    ).toBe('https://api.loora.design/api/asset/asset-id')
+  })
+
+  test('sends local asset requests to the local API service', () => {
+    expect(
+      apiAssetUrl(
+        new Request('http://localhost:3000/api/asset/asset-id'),
+        'asset-id',
+      ).toString(),
+    ).toBe('http://localhost:3001/api/asset/asset-id')
+  })
+})

--- a/apps/web/src/routes/api.asset.$id.ts
+++ b/apps/web/src/routes/api.asset.$id.ts
@@ -1,63 +1,19 @@
 import '@tanstack/react-start'
 import { createFileRoute } from '@tanstack/react-router'
-import { and, eq } from 'drizzle-orm'
-import { db } from '@loora/db'
-import { asset } from '@loora/db/schema'
-import { requireSession } from '@loora/auth'
-import { authorizeBilling, subscriptionRequiredResponse } from '@loora/billing/billing'
-import { canUseApp, previewAccessRequiredResponse } from '@loora/auth/preview-access'
-import {
-  hasAcceptedCurrentLegal,
-  legalConsentRequiredResponse,
-} from '@loora/auth/legal-consent'
-import { s3 } from '@loora/rpc/storage'
-import {
-  rateLimit,
-  rateLimits,
-  tooManyRequestsResponse,
-} from '@loora/rpc/rate-limit'
+
+export function apiAssetUrl(request: Request, id: string) {
+  const requestUrl = new URL(request.url)
+  const apiOrigin = requestUrl.hostname === 'localhost'
+    ? 'http://localhost:3001'
+    : 'https://api.loora.design'
+  return new URL(`/api/asset/${encodeURIComponent(id)}`, apiOrigin)
+}
 
 export const Route = createFileRoute('/api/asset/$id')({
   server: {
     handlers: {
       GET: async ({ request, params }) => {
-        const session = await requireSession(request)
-        if (!session) return new Response('Unauthorized', { status: 401 })
-        // Serving an asset means a row read and, usually, a bucket fetch, so
-        // the count comes before either of them.
-        const decision = await rateLimit(
-          'asset',
-          `user:${session.user.id}`,
-          rateLimits.asset,
-        )
-        if (!decision.ok) return tooManyRequestsResponse(decision)
-
-        if (!hasAcceptedCurrentLegal(session.user)) return legalConsentRequiredResponse()
-        if (!canUseApp(session.user)) return previewAccessRequiredResponse()
-        if (!(await authorizeBilling(session.user)).access) return subscriptionRequiredResponse()
-
-        const [found] = await db
-          .select({ data: asset.data, storageKey: asset.storageKey, mediaType: asset.mediaType })
-          .from(asset)
-          .where(and(eq(asset.id, params.id), eq(asset.userId, session.user.id)))
-          .limit(1)
-
-        if (!found) return new Response('Not found', { status: 404 })
-
-        let bytes: Uint8Array
-        if (found.storageKey && s3) {
-          bytes = new Uint8Array(await s3.file(found.storageKey).arrayBuffer())
-        } else if (found.data) {
-          bytes = Uint8Array.from(atob(found.data), (c) => c.charCodeAt(0))
-        } else {
-          return new Response('Asset payload unavailable', { status: 500 })
-        }
-        return new Response(new Blob([bytes as Uint8Array<ArrayBuffer>]), {
-          headers: {
-            'Content-Type': found.mediaType,
-            'Cache-Control': 'private, max-age=31536000, immutable',
-          },
-        })
+        return Response.redirect(apiAssetUrl(request, params.id), 307)
       },
     },
   },

--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,23 @@
         "vitest": "4.1.6",
       },
     },
+    "apps/api": {
+      "name": "@loora/api",
+      "dependencies": {
+        "@loora/auth": "workspace:*",
+        "@loora/billing": "workspace:*",
+        "@loora/db": "workspace:*",
+        "@loora/realtime": "workspace:*",
+        "@loora/rpc": "workspace:*",
+        "@orpc/server": "^1.14.8",
+        "drizzle-orm": "catalog:",
+        "hono": "^4.9.6",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.14",
+        "typescript": "catalog:",
+      },
+    },
     "apps/desktop": {
       "name": "@loora/desktop",
       "dependencies": {
@@ -511,6 +528,8 @@
     "@levischuck/tiny-cbor": ["@levischuck/tiny-cbor@0.2.11", "", {}, "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow=="],
 
     "@loora/agent": ["@loora/agent@workspace:packages/agent"],
+
+    "@loora/api": ["@loora/api@workspace:apps/api"],
 
     "@loora/auth": ["@loora/auth@workspace:packages/auth"],
 

--- a/crates/mcp-server/Dockerfile
+++ b/crates/mcp-server/Dockerfile
@@ -4,6 +4,7 @@ FROM rust:1-bookworm AS builder
 WORKDIR /app
 
 COPY Cargo.toml Cargo.lock ./
+COPY apps/api/package.json apps/api/package.json
 COPY crates/ws-server/Cargo.toml crates/ws-server/Cargo.toml
 COPY crates/mcp-server/Cargo.toml crates/mcp-server/Cargo.toml
 RUN mkdir -p crates/ws-server/src && printf 'fn main() {}\n' > crates/ws-server/src/main.rs

--- a/crates/ws-server/Dockerfile
+++ b/crates/ws-server/Dockerfile
@@ -4,6 +4,7 @@ FROM rust:1-bookworm AS builder
 WORKDIR /app
 
 COPY Cargo.toml Cargo.lock ./
+COPY apps/api/package.json apps/api/package.json
 COPY crates/ws-server/Cargo.toml crates/ws-server/Cargo.toml
 COPY crates/mcp-server/Cargo.toml crates/mcp-server/Cargo.toml
 RUN mkdir -p crates/ws-server/src && printf 'fn main() {}\n' > crates/ws-server/src/main.rs

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "private": true,
   "scripts": {
     "dev": "bun run --cwd apps/web dev",
+    "dev:api": "bun run --cwd apps/api dev",
     "dev:desktop": "bun run --cwd apps/desktop dev",
     "dev:ws": "cargo run -p loora-ws-server",
     "dev:mcp": "cargo run -p loora-mcp-server",
@@ -27,6 +28,7 @@
     "docs:build": "bun run --cwd apps/docs build",
     "preview": "bun run --cwd apps/web preview",
     "start": "bun run --cwd apps/web start",
+    "start:api": "bun run --cwd apps/api start",
     "test": "vitest run",
     "generate-routes": "bun run --cwd apps/web generate-routes",
     "db:generate": "bun run --cwd packages/db generate",

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -10,7 +10,6 @@ import {
   oneTimeToken,
   twoFactor,
 } from 'better-auth/plugins'
-import { tanstackStartCookies } from 'better-auth/tanstack-start'
 import { polar, portal, webhooks } from '@polar-sh/better-auth'
 import { db } from '@loora/db'
 import * as schema from '@loora/db/schema'
@@ -30,11 +29,23 @@ import {
 const googleClientId = process.env.GOOGLE_CLIENT_ID?.trim()
 const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET?.trim()
 const polarRuntime = getPolarRuntime()
+const configuredAllowedOrigins = (process.env.API_ALLOWED_ORIGINS || '')
+  .split(',')
+  .map((origin) => origin.trim())
+  .filter(Boolean)
+const appOrigin = process.env.APP_ORIGIN?.trim().replace(/\/+$/, '') || 'http://localhost:3000'
+const trustedOrigins = Array.from(new Set([
+  appOrigin,
+  ...(configuredAllowedOrigins.length > 0
+    ? configuredAllowedOrigins
+    : ['http://localhost:3000', 'https://loora.design']),
+]))
 
 export const googleOAuthEnabled = Boolean(googleClientId && googleClientSecret)
 
 export const auth = betterAuth({
   baseURL: process.env.BETTER_AUTH_URL,
+  trustedOrigins,
   database: drizzleAdapter(db, {
     provider: 'pg',
     schema,
@@ -204,10 +215,10 @@ export const auth = betterAuth({
     // exists. The resource server validates the issued tokens against the
     // same database through the Rust MCP resource server.
     mcp({
-      loginPage: '/',
+      loginPage: `${appOrigin}/`,
       oidcConfig: {
-        loginPage: '/',
-        consentPage: '/mcp-consent',
+        loginPage: `${appOrigin}/`,
+        consentPage: `${appOrigin}/mcp-consent`,
         // The 1h default meant a connected editor died mid-session every hour;
         // clients that do refresh then churn a token per hour, and clients that
         // don't just stop working. A working day of access, a month of refresh.
@@ -245,9 +256,6 @@ export const auth = betterAuth({
         },
       },
     }),
-    // Cookie integration must be last so plugins with `hooks.after` (like
-    // twoFactor) still see their Set-Cookie headers forwarded to the framework.
-    tanstackStartCookies(),
   ],
 })
 

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -34,6 +34,7 @@ const configuredAllowedOrigins = (process.env.API_ALLOWED_ORIGINS || '')
   .map((origin) => origin.trim())
   .filter(Boolean)
 const appOrigin = process.env.APP_ORIGIN?.trim().replace(/\/+$/, '') || 'http://localhost:3000'
+const appHostname = new URL(appOrigin).hostname
 const trustedOrigins = Array.from(new Set([
   appOrigin,
   ...(configuredAllowedOrigins.length > 0
@@ -243,7 +244,9 @@ export const auth = betterAuth({
       customPasswordCompromisedMessage:
         'This password has appeared in a data breach. Please choose a different one.',
     }),
-    passkey(),
+    // WebAuthn runs in the app window even though its challenge endpoints are
+    // served by the API subdomain. Keep credentials bound to the app's RP ID.
+    passkey({ rpID: appHostname, rpName: 'Loora', origin: appOrigin }),
     twoFactor({
       issuer: 'Loora',
       otpOptions: {

--- a/packages/billing/src/polar.test.ts
+++ b/packages/billing/src/polar.test.ts
@@ -51,6 +51,14 @@ describe('Polar configuration', () => {
     })
   })
 
+  test('returns to the app when auth is served from a separate origin', () => {
+    expect(resolvePolarConfig({
+      ...complete,
+      APP_ORIGIN: 'https://loora.design/app',
+      BETTER_AUTH_URL: 'https://api.loora.design',
+    }).config?.origin).toBe('https://loora.design')
+  })
+
   test('keeps the legacy Studio product optional', () => {
     expect(resolvePolarConfig({
       ...complete,

--- a/packages/billing/src/polar.ts
+++ b/packages/billing/src/polar.ts
@@ -50,9 +50,9 @@ export function resolvePolarConfig(
 
   let origin: string
   try {
-    origin = new URL(values.BETTER_AUTH_URL!).origin
+    origin = new URL(env.APP_ORIGIN?.trim() || values.BETTER_AUTH_URL!).origin
   } catch {
-    throw new Error('BETTER_AUTH_URL must be an absolute URL')
+    throw new Error('APP_ORIGIN or BETTER_AUTH_URL must be an absolute URL')
   }
 
   return {

--- a/packages/editor/src/components/assets-panel.test.tsx
+++ b/packages/editor/src/components/assets-panel.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, fireEvent, render, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, vi, test } from 'vitest'
+import { configureRuntime } from '@loora/platform'
 
 const list = vi.fn()
 const upload = vi.fn()
@@ -9,7 +10,7 @@ vi.doMock('@loora/rpc/client', () => ({
   orpc: { asset: { list, upload, delete: remove } },
 }))
 
-const { AssetsPanel } = await import('./assets-panel')
+const { absoluteAssetSrc, AssetsPanel } = await import('./assets-panel')
 
 const HOUR = 3_600_000
 
@@ -50,7 +51,18 @@ describe('AssetsPanel', () => {
     remove.mockReset().mockResolvedValue({ deleted: true })
   })
 
-  afterEach(() => cleanup())
+  afterEach(() => {
+    cleanup()
+    configureRuntime({ apiOrigin: '' })
+  })
+
+  test('resolves authenticated asset routes against the API origin', () => {
+    configureRuntime({ apiOrigin: 'https://api.loora.test' })
+
+    expect(absoluteAssetSrc({ id: 'a1' })).toBe(
+      'https://api.loora.test/api/asset/a1',
+    )
+  })
 
   test('lists assets with their size and places one on click', async () => {
     const { view, onInsert } = setup()

--- a/packages/editor/src/components/assets-panel.tsx
+++ b/packages/editor/src/components/assets-panel.tsx
@@ -14,7 +14,7 @@ import { Input } from '@loora/ui/input'
 import { Skeleton } from '@loora/ui/skeleton'
 import { orpc } from '@loora/rpc/client'
 import { assetRouteUrl } from '@loora/rpc/asset-url'
-import { appUrl } from '@loora/platform'
+import { apiUrl, appUrl } from '@loora/platform'
 import { relativeTime } from '../lib/designs'
 import { cn } from '@loora/ui/utils'
 
@@ -40,6 +40,7 @@ export function assetSrc(asset: Pick<AssetMeta, 'id' | 'url'>) {
 /** Same URL, absolute — for the clipboard and drag payloads. */
 export function absoluteAssetSrc(asset: Pick<AssetMeta, 'id' | 'url'>) {
   const src = assetSrc(asset)
+  if (src.startsWith('/api/')) return apiUrl(src)
   return src.startsWith('/') ? appUrl(src) : src
 }
 

--- a/packages/editor/src/components/export-panel.tsx
+++ b/packages/editor/src/components/export-panel.tsx
@@ -42,7 +42,7 @@ import {
 import { captureCanvasPng, captureNodePng } from '../lib/canvas-capture'
 import { copyText } from '../lib/copy-text'
 import { orpc } from '@loora/rpc/client'
-import { appUrl } from '@loora/platform'
+import { apiUrl, appUrl } from '@loora/platform'
 import { Button } from '@loora/ui/button'
 import {
   Dialog,
@@ -328,7 +328,11 @@ async function embedImages(sources: string[]) {
         while (cursor < sources.length) {
           const src = sources[cursor++]!
           try {
-            const response = await fetch(src, { credentials: 'same-origin' })
+            const authenticatedAsset = src.startsWith('/api/asset/')
+            const response = await fetch(
+              authenticatedAsset ? apiUrl(src) : src,
+              { credentials: authenticatedAsset ? 'include' : 'same-origin' },
+            )
             if (!response.ok) continue
             const blob = await response.blob()
             const data = await new Promise<string>((resolve, reject) => {
@@ -759,7 +763,7 @@ export function CanvasExport({
         draftId: controller.target.draftId,
       })
       setHandoff({
-        url: appUrl(`/api/handoff/${created.token}`),
+        url: apiUrl(`/api/handoff/${created.token}`),
         expiresAt: created.expiresAt,
       })
     } catch {

--- a/packages/editor/src/lib/canvas-client.ts
+++ b/packages/editor/src/lib/canvas-client.ts
@@ -563,11 +563,12 @@ export class CanvasSyncController {
       ...(leaving ? { leaving: true } : {}),
     })
     try {
-      const response = await fetch('/api/canvas-presence', {
+      const response = await fetch(apiUrl('/api/canvas-presence'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body,
         keepalive: leaving,
+        credentials: 'include',
       })
       if (response.ok && !leaving) {
         const scoped = (await response.json()) as { sessionId?: unknown }
@@ -932,13 +933,14 @@ export class CanvasSyncController {
     let ticket: { url?: unknown; ticket?: unknown; sessionId?: unknown } | null =
       null
     try {
-      const response = await fetch('/api/realtime-ticket', {
+      const response = await fetch(apiUrl('/api/realtime-ticket'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           designId: this.target.designId,
           draftId: this.target.draftId,
         }),
+        credentials: 'include',
       })
       // 503 is how the app says "no socket service here" — not a failure worth
       // retrying, so this controller stays on the event stream from now on.
@@ -980,7 +982,7 @@ export class CanvasSyncController {
     if (this.target.draftId) {
       url.searchParams.set('draftId', this.target.draftId)
     }
-    const source = new EventSource(url)
+    const source = new EventSource(url, { withCredentials: true })
     this.#eventSource = source
     source.addEventListener('open', this.#realtimeOpen)
     source.addEventListener('ready', this.#realtimeReady)

--- a/packages/editor/src/lib/canvas-presence-transport.test.ts
+++ b/packages/editor/src/lib/canvas-presence-transport.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, describe, expect, vi, test } from 'vitest'
+import { afterEach, beforeEach, describe, expect, vi, test } from 'vitest'
 import { createCanvasDocument } from '@loora/canvas/model'
+import { configureRuntime } from '@loora/platform'
 
 vi.doMock('@loora/rpc/client', () => ({
   orpc: {
@@ -15,6 +16,7 @@ const { CanvasSyncController } = await import('./canvas-client')
 interface FetchCall {
   url: string
   body: unknown
+  credentials: RequestCredentials | undefined
 }
 
 /**
@@ -32,7 +34,7 @@ function stubFetch(ticket: (() => Promise<Response>) | null) {
     } catch {
       body = init?.body ?? null
     }
-    calls.push({ url, body })
+    calls.push({ url, body, credentials: init?.credentials })
     if (url.includes('/api/realtime-ticket')) {
       // No ticket source means "stay pending forever" for this test.
       return ticket ? ticket() : new Promise<Response>(() => {})
@@ -43,6 +45,7 @@ function stubFetch(ticket: (() => Promise<Response>) | null) {
 }
 
 const originalFetch = globalThis.fetch
+const originalEventSource = globalThis.EventSource
 
 async function openController() {
   const controller = await CanvasSyncController.open(
@@ -56,8 +59,14 @@ async function openController() {
 }
 
 describe('presence transport', () => {
+  beforeEach(() => {
+    configureRuntime({ apiOrigin: 'https://api.loora.test' })
+  })
+
   afterEach(() => {
     globalThis.fetch = originalFetch
+    globalThis.EventSource = originalEventSource
+    configureRuntime({ apiOrigin: '' })
   })
 
   test('posts nothing over HTTP while the socket is still being ticketed', async () => {
@@ -67,12 +76,34 @@ describe('presence transport', () => {
     controller.publishPresence({ cursor: { x: 12, y: 20 }, selection: ['hero'] })
     await new Promise((resolve) => setTimeout(resolve, 120))
 
-    expect(calls.some((call) => call.url.includes('/api/realtime-ticket'))).toBe(true)
+    expect(
+      calls.some(
+        (call) =>
+          call.url === 'https://api.loora.test/api/realtime-ticket' &&
+          call.credentials === 'include',
+      ),
+    ).toBe(true)
     expect(calls.some((call) => call.url.includes('/api/canvas-presence'))).toBe(false)
     await controller.close()
   })
 
   test('falls back to posting presence when realtime is not configured', async () => {
+    let eventSource:
+      | { url: string; withCredentials: boolean | undefined }
+      | undefined
+    class FakeEventSource {
+      constructor(url: string | URL, init?: EventSourceInit) {
+        eventSource = {
+          url: String(url),
+          withCredentials: init?.withCredentials,
+        }
+      }
+
+      addEventListener() {}
+      removeEventListener() {}
+      close() {}
+    }
+    globalThis.EventSource = FakeEventSource as unknown as typeof EventSource
     const calls = stubFetch(
       async () => new Response(JSON.stringify({ configured: false }), { status: 503 }),
     )
@@ -86,6 +117,16 @@ describe('presence transport', () => {
     expect(presence.at(-1)?.body).toMatchObject({
       designId: 'design-1',
       cursor: { x: 4, y: 8 },
+    })
+    expect(presence.at(-1)?.credentials).toBe('include')
+    expect(presence.at(-1)?.url).toBe(
+      'https://api.loora.test/api/canvas-presence',
+    )
+    expect(eventSource).toMatchObject({
+      url: expect.stringContaining(
+        'https://api.loora.test/api/canvas-events?designId=design-1',
+      ),
+      withCredentials: true,
     })
     await controller.close()
   })

--- a/packages/platform/src/runtime.ts
+++ b/packages/platform/src/runtime.ts
@@ -1,12 +1,11 @@
 /**
  * Where the client is running, and how it reaches Loora.
  *
- * The web app is served by the origin it calls, so every default here is "my
- * own origin" and web code behaves exactly as it did before this module
- * existed. The desktop app is served by a loopback server in its own process
- * that proxies `/api/*` on to loora.design with the session token attached —
- * so its API origin is also its own, but a link meant for a browser has to
- * point at the public app rather than at `http://127.0.0.1:<port>`.
+ * Defaults use the document's own origin. The web entry point configures its
+ * separate API service before client modules load. The desktop app is served
+ * by a loopback server in its own process that proxies `/api/*` with the
+ * session token attached, so its API origin remains its own; only links meant
+ * for a browser point at the public app instead of `http://127.0.0.1:<port>`.
  *
  * Nothing in here imports anything: it is the one module every layer
  * (`@loora/rpc/client`, `@loora/auth/client`, the editor) may depend on.

--- a/packages/rpc/src/client.ts
+++ b/packages/rpc/src/client.ts
@@ -8,12 +8,14 @@ import type { appRouter } from './router.ts'
  * The browser half of the router. `appRouter` is a type-only import, so none
  * of the server implementation follows it into the client bundle.
  *
- * The URL comes from the platform runtime: the web app calls its own origin,
- * and the desktop app calls the loopback server in its own process, which
- * proxies on to loora.design with the session it holds.
+ * The URL comes from the platform runtime: the web app calls the configured
+ * API origin, and the desktop app calls the loopback server in its own process,
+ * which proxies on to Loora with the session it holds.
  */
 const link = new RPCLink({
   url: () => apiUrl('/api/rpc'),
+  fetch: (request, init) =>
+    globalThis.fetch(request, { ...init, credentials: 'include' }),
 })
 
 export const orpc: RouterClient<typeof appRouter> = createORPCClient(link)

--- a/packages/rpc/src/readiness.ts
+++ b/packages/rpc/src/readiness.ts
@@ -1,5 +1,5 @@
 export async function serviceReadinessResponse(
-  service: 'web' | 'mcp',
+  service: 'web' | 'api' | 'mcp',
   checkDatabase: () => Promise<void>,
 ) {
   try {

--- a/packages/rpc/src/request-timing.ts
+++ b/packages/rpc/src/request-timing.ts
@@ -54,7 +54,7 @@ function isRequestTimingLogEnabled() {
 }
 
 export function logRequestTiming(input: {
-  service: 'web' | 'mcp'
+  service: 'web' | 'api' | 'mcp'
   requestId: string
   method: string
   path: string

--- a/packages/shell/src/components/github-account.tsx
+++ b/packages/shell/src/components/github-account.tsx
@@ -9,6 +9,7 @@ import { UnplugIcon } from '@loora/ui/icons'
 import { Button } from '@loora/ui/button'
 import { IntegrationCard, IntegrationStatus } from './integration-card'
 import { orpc } from '@loora/rpc/client'
+import { apiUrl } from '@loora/platform'
 
 type GitHubStatus = Awaited<ReturnType<typeof orpc.github.status>>
 
@@ -87,7 +88,11 @@ export function GitHubAccount() {
         status={<IntegrationStatus>Not connected</IntegrationStatus>}
         description="Give Loora read-only access to repositories you choose. Relevant source files and images may be sent to your selected AI provider when the agent inspects them."
       >
-        <Button size="sm" className="w-fit" onClick={() => window.location.assign('/api/github/connect')}>
+        <Button
+          size="sm"
+          className="w-fit"
+          onClick={() => window.location.assign(apiUrl('/api/github/connect'))}
+        >
           <GithubIcon data-slot="icon" />
           Connect GitHub
         </Button>
@@ -141,7 +146,11 @@ export function GitHubAccount() {
         )}
 
         <div className="flex flex-wrap gap-2">
-          <Button size="sm" variant="outline" onClick={() => window.location.assign('/api/github/install')}>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => window.location.assign(apiUrl('/api/github/install'))}
+          >
             <PlusIcon data-slot="icon" />
             Add repositories
           </Button>


### PR DESCRIPTION
## Summary

- add a standalone Bun/Hono API service while preserving the existing oRPC router and procedure contracts
- move auth, assets, realtime, GitHub, handoff, internal MCP, readiness, and custom-domain endpoints to `apps/api`
- configure the web and desktop clients for the separate `https://api.loora.design` origin with credentialed CORS
- separate app and API origins for Better Auth, MCP consent, Polar return URLs, and the desktop host
- add Railway/Docker deployment configuration and make the API service the migration owner

## Production

- Railway service `Loora API` is deployed and healthy
- `https://api.loora.design/api/ready` returns database-ready status
- production MCP traffic now targets `https://api.loora.design/api/internal/mcp`
- `api.loora.design` has a valid certificate and is live through Cloudflare

## Configuration

Production requires:

```env
BETTER_AUTH_URL=https://api.loora.design
APP_ORIGIN=https://loora.design
API_ALLOWED_ORIGINS=https://loora.design
```

Google/GitHub callback URLs and Polar webhooks should be updated to use `api.loora.design` before the web client cutover.

## Validation

- `bunx tsc --noEmit`
- `bun run --cwd apps/api typecheck`
- `bun run check:desktop`
- `bun run test` (98 files, 637 tests)
- `bun run build`
- API routing, credentialed CORS, public handoff CORS, auth session, readiness, and internal MCP production smoke checks
