### PR TITLE
ui: empty-frame CTA, Desktop artboard, deferred Fit All

### DIFF
--- a/crates/engine/src/model.rs
+++ b/crates/engine/src/model.rs
@@ -820,18 +820,26 @@ impl Node {
     }
 
     pub fn root_frame(name: impl Into<String>) -> Self {
-        Self::base(
+        let mut node = Self::base(
             "frame",
             NodeKind::Frame,
             name,
             None,
             Layout::new(0.0, 0.0, 1440.0, 900.0),
             Style {
-                fills: vec![Paint::solid(Color::rgb(0x1a, 0x1a, 0x1a))],
+                // Slightly lighter than the canvas chrome (`#0f0f10`) so the
+                // artboard reads as a page, with a soft edge against the void.
+                fills: vec![Paint::solid(Color::rgb(0x18, 0x18, 0x1a))],
+                stroke: Some(Stroke::solid(Color::rgba(1.0, 1.0, 1.0, 0.06), 1.0)),
                 overflow: Overflow::Hidden,
                 ..Style::default()
             },
-        )
+        );
+        node.viewport = Some(crate::extras::PageViewport {
+            width: 1440.0,
+            min_height: 900.0,
+        });
+        node
     }
 
     pub fn frame(name: impl Into<String>, parent_id: NodeId, layout: Layout) -> Self {
@@ -1286,7 +1294,7 @@ fn default_theme_id() -> String {
 
 impl Document {
     pub fn empty(name: impl Into<String>) -> Self {
-        let frame = Node::root_frame("Frame 1");
+        let frame = Node::root_frame("Desktop");
         let root_page_id = frame.id.clone();
         let mut nodes = std::collections::HashMap::new();
         nodes.insert(frame.id.clone(), frame);
@@ -1413,8 +1421,13 @@ mod tests {
         let document = Document::empty("Frame document");
         let root = document.nodes.get(&document.root_page_id).unwrap();
         assert_eq!(root.kind, NodeKind::Frame);
+        assert_eq!(root.name, "Desktop");
         assert!(root.is_root_frame());
         assert_eq!(root.style.overflow, Overflow::Hidden);
+        assert!(root.style.stroke.is_some());
+        let viewport = root.viewport.expect("root page viewport");
+        assert!((viewport.width - 1440.0).abs() < f64::EPSILON);
+        assert!((viewport.min_height - 900.0).abs() < f64::EPSILON);
         assert_eq!(serde_json::to_value(root.kind).unwrap(), "frame");
     }
 

--- a/crates/ui/src/canvas/web_canvas.rs
+++ b/crates/ui/src/canvas/web_canvas.rs
@@ -641,6 +641,12 @@ html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:
 .loora-context-item.is-destructive{color:#ff6b72}
 .loora-context-shortcut{margin-left:24px;color:color-mix(in srgb,var(--loora-toolbar-fg) 62%,transparent);font-size:11px}
 .loora-context-separator{height:1px;margin:4px 8px;background:var(--loora-toolbar-border)}
+#loora-empty{position:absolute;left:50%;top:46%;transform:translate(-50%,-50%);display:flex;flex-direction:column;align-items:center;gap:10px;z-index:50;pointer-events:auto;user-select:none}
+#loora-empty[hidden]{display:none}
+#loora-empty .loora-empty-copy{font:500 13px/1.2 -apple-system,BlinkMacSystemFont,sans-serif;color:color-mix(in srgb,var(--loora-surface-fg) 45%,transparent);letter-spacing:.01em;pointer-events:none}
+#loora-empty .loora-empty-cta{pointer-events:auto;height:28px;padding:0 12px;border-radius:8px;border:1px solid var(--loora-toolbar-border);background:var(--loora-toolbar-bg);color:var(--loora-toolbar-fg);font:500 12px/26px -apple-system,BlinkMacSystemFont,sans-serif;cursor:pointer;box-shadow:var(--loora-toolbar-shadow)}
+#loora-empty .loora-empty-cta:hover{background:var(--loora-toolbar-hover);color:var(--loora-toolbar-active-fg)}
+.loora-preview #loora-empty{display:none}
 </style>
 <style id="loora-document-css"></style>
 </head>
@@ -665,6 +671,10 @@ html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:
       <button type="button" class="loora-action" data-cmd="redo" data-tip="Redo  ⌘⇧Z" id="loora-redo"><svg viewBox="0 0 24 24" fill="none"><path d="M20 10H10a5 5 0 1 0 0 10h5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="m16 6 4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
   </div>
   <button type="button" id="loora-zoom" data-cmd="fit-selection">100%</button>
+  <div id="loora-empty" hidden>
+    <div class="loora-empty-copy">Empty frame</div>
+    <button type="button" class="loora-empty-cta" data-tool="rectangle">Draw a rectangle · R</button>
+  </div>
   <div id="loora-context-menu" role="menu" hidden></div>
 </div>
 <script>
@@ -792,6 +802,17 @@ html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:
     event.stopPropagation();
     if (btn.dataset.tool) post('command', { command: `tool:${btn.dataset.tool}` });
     else if (btn.dataset.cmd) post('command', { command: btn.dataset.cmd });
+  });
+  const emptyHost = document.getElementById('loora-empty');
+  emptyHost?.addEventListener('pointerdown', event => {
+    event.stopPropagation();
+  });
+  emptyHost?.addEventListener('click', event => {
+    const btn = event.target.closest('[data-tool]');
+    if (!btn) return;
+    event.preventDefault();
+    event.stopPropagation();
+    post('command', { command: `tool:${btn.dataset.tool}` });
   });
   zoomChip?.addEventListener('pointerdown', event => event.stopPropagation());
   zoomChip?.addEventListener('click', event => {
@@ -1799,6 +1820,16 @@ html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:
     state.camera.y = height/2-(top+bottom)/2*state.camera.zoom;
     cameraTransform(); queueCamera();
   };
+  const syncEmptyHints = () => {
+    if (!emptyHost) return;
+    if (state.preview) {
+      emptyHost.hidden = true;
+      return;
+    }
+    const hosts = [...scene.querySelectorAll('.loora-page-host:not([data-loora-overlay-page])')];
+    const empty = hosts.some(host => !host.querySelector('[data-loora-node]:not([data-loora-root])'));
+    emptyHost.hidden = !empty;
+  };
   const focusPage = id => {
     const node = nodeForId(id); if (!node) return;
     const rect = worldRect(node), width=surface.clientWidth, height=surface.clientHeight, padding=72;
@@ -1835,6 +1866,7 @@ html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:
     surface.dataset.tool = state.tool;
     cameraTransform();
     setSelection(payload.selection || []);
+    syncEmptyHints();
     requestAnimationFrame(() => { syncHandles(); syncOverlay(); });
   };
   const exportPng = () => {
@@ -2007,6 +2039,17 @@ mod tests {
         assert!(CANVAS_SHELL.contains("command.type === 'context-menu'"));
         assert!(CANVAS_SHELL.contains("post('context-action', { action })"));
         assert!(CANVAS_SHELL.contains("window.addEventListener('blur', hideContextMenu)"));
+    }
+
+    #[test]
+    fn webview_empty_frame_shows_cta() {
+        assert!(CANVAS_SHELL.contains("id=\"loora-empty\""));
+        assert!(CANVAS_SHELL.contains("const syncEmptyHints"));
+        assert!(CANVAS_SHELL.contains("Empty frame"));
+        assert!(CANVAS_SHELL.contains("[data-loora-node]:not([data-loora-root])"));
+        assert!(CANVAS_SHELL.contains("Draw a rectangle · R"));
+        assert!(CANVAS_SHELL.contains("syncEmptyHints()"));
+        assert!(CANVAS_SHELL.contains(".loora-preview #loora-empty{display:none}"));
     }
 
     #[test]

--- a/crates/ui/src/canvas/workspace.rs
+++ b/crates/ui/src/canvas/workspace.rs
@@ -147,6 +147,8 @@ pub struct CanvasWorkspace {
     web_document_key: Option<WebDocumentKey>,
     web_state_key: Option<WebStateKey>,
     web_ready: bool,
+    /// Fit-all deferred until the webview viewport has a real size.
+    pending_fit_all: bool,
     /// Path waiting for a webview PNG rasterization result.
     pending_png_export: Option<PathBuf>,
     pub(crate) collapsed: HashSet<NodeId>,
@@ -318,6 +320,7 @@ impl CanvasWorkspace {
             web_document_key: None,
             web_state_key: None,
             web_ready: false,
+            pending_fit_all: true,
             pending_png_export: None,
             collapsed,
             collapsed_generation: 0,
@@ -403,6 +406,9 @@ impl CanvasWorkspace {
                 }
             }
         }));
+        // Cold start never went through load_document — fit once the viewport exists.
+        workspace.pending_fit_all = true;
+        workspace.fit_all_pages(cx);
         workspace
     }
 
@@ -488,6 +494,7 @@ impl CanvasWorkspace {
                 self.web_ready = true;
                 self.web_document_key = None;
                 self.web_state_key = None;
+                self.flush_pending_fit_all(cx);
             }
             "export-png" => {
                 let Some(path) = self.pending_png_export.take() else {
@@ -1187,6 +1194,9 @@ impl CanvasWorkspace {
         let hide_webview = self.webview_should_be_hidden();
         self.webview
             .update(cx, |view, _| view.set_visible(!hide_webview));
+        if !hide_webview {
+            self.flush_pending_fit_all(cx);
+        }
         if !self.web_ready || hide_webview {
             return;
         }
@@ -1725,6 +1735,7 @@ impl CanvasWorkspace {
         self.note_collapsed_changed();
         self.camera = Camera::new(Vec2::new(40.0, 40.0), 1.0);
         self.refresh_files();
+        self.pending_fit_all = true;
         self.fit_all_pages(cx);
     }
 
@@ -5217,6 +5228,7 @@ impl CanvasWorkspace {
             });
         }
         let Some(bounds) = union else {
+            self.pending_fit_all = false;
             cx.notify();
             return;
         };
@@ -5225,8 +5237,23 @@ impl CanvasWorkspace {
         let h = f32::from(vb.size.height) as f64;
         if w > 1.0 && h > 1.0 {
             self.camera.fit_bounds(w, h, bounds, 72.0);
+            self.pending_fit_all = false;
+        } else {
+            self.pending_fit_all = true;
         }
         cx.notify();
+    }
+
+    fn flush_pending_fit_all(&mut self, cx: &mut Context<Self>) {
+        if !self.pending_fit_all {
+            return;
+        }
+        let vb = self.viewport_bounds.get();
+        let w = f32::from(vb.size.width) as f64;
+        let h = f32::from(vb.size.height) as f64;
+        if w > 1.0 && h > 1.0 {
+            self.fit_all_pages(cx);
+        }
     }
 
     pub fn group_selection(&mut self, cx: &mut Context<Self>) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Product polish for blank / new designs:

1. **Clearer default artboard** — `Document::empty` roots are named `Desktop`, carry a 1440×900 viewport, slightly lifted fill vs canvas chrome, and a soft edge stroke.
2. **Fit All on open** — `pending_fit_all` defers camera fit until the webview viewport has a real size (fixes cold start and early `load_document` no-ops).
3. **Empty-frame CTA** — when a page has no non-root children, show muted “Empty frame” + “Draw a rectangle · R” (`#loora-empty` chrome peer, same hit model as the toolbar).

### Validation
- `cargo test` — `root_artboard_is_a_clipped_frame`, `webview_empty_frame_shows_cta`
- `just check`
- GUI: new design shows **Desktop** in Layers; frame fitted (~29% zoom); empty CTA visible

[Empty frame CTA on new Desktop artboard](https://cursor.com/agents/bc-3040b235-af69-45b2-b135-dfa455542015/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Floora_empty_frame_cta.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3040b235-af69-45b2-b135-dfa455542015?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3040b235-af69-45b2-b135-dfa455542015&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

