### PR TITLE
fix(ui): Ctrl+N/O/S/R when wry canvas webview has focus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3572,6 +3572,7 @@ version = "0.1.0"
 dependencies = [
  "async-channel",
  "base64",
+ "gdkx11",
  "gpui",
  "gpui-router",
  "gtk",
@@ -3579,7 +3580,9 @@ dependencies = [
  "loora-engine",
  "raw-window-handle",
  "serde_json",
+ "webkit2gtk",
  "wry",
+ "x11-dl",
 ]
 
 [[package]]

--- a/crates/desktop/src/app_root.rs
+++ b/crates/desktop/src/app_root.rs
@@ -5,7 +5,8 @@ use gpui::{
 };
 use gpui_router::{use_location, Route, Routes};
 use loora_ui::{
-    CanvasWorkspace, SettingsSection, SettingsSectionPage, SettingsShell, ToggleSettings,
+    CanvasWorkspace, NewDesign, SaveDesign, SettingsSection, SettingsSectionPage, SettingsShell,
+    ToggleFiles, ToggleSettings,
 };
 
 pub struct AppRoot {
@@ -26,6 +27,15 @@ impl AppRoot {
         cx.bind_keys([
             KeyBinding::new("cmd-,", ToggleSettings, None),
             KeyBinding::new("ctrl-,", ToggleSettings, None),
+            KeyBinding::new("cmd-n", NewDesign, None),
+            KeyBinding::new("ctrl-n", NewDesign, None),
+            KeyBinding::new("secondary-n", NewDesign, None),
+            KeyBinding::new("cmd-o", ToggleFiles, None),
+            KeyBinding::new("ctrl-o", ToggleFiles, None),
+            KeyBinding::new("secondary-o", ToggleFiles, None),
+            KeyBinding::new("cmd-s", SaveDesign, None),
+            KeyBinding::new("ctrl-s", SaveDesign, None),
+            KeyBinding::new("secondary-s", SaveDesign, None),
         ]);
 
         Self {
@@ -49,6 +59,39 @@ impl AppRoot {
         gpui_router::RouterState::global_mut(cx).with_path(next.into());
         window.refresh();
         cx.notify();
+    }
+
+    fn new_design(&mut self, _: &NewDesign, _: &mut Window, cx: &mut Context<Self>) {
+        // Ensure we're on the canvas route, then create.
+        if cx.has_global::<gpui_router::RouterState>() {
+            let path = use_location(cx).pathname.to_string();
+            if path.starts_with("/settings") {
+                gpui_router::RouterState::global_mut(cx).with_path("/".into());
+            }
+        }
+        self.canvas.update(cx, |workspace, cx| {
+            workspace.create_design(cx);
+        });
+        cx.notify();
+    }
+
+    fn toggle_files(&mut self, _: &ToggleFiles, window: &mut Window, cx: &mut Context<Self>) {
+        if cx.has_global::<gpui_router::RouterState>() {
+            let path = use_location(cx).pathname.to_string();
+            if path.starts_with("/settings") {
+                gpui_router::RouterState::global_mut(cx).with_path("/".into());
+                window.refresh();
+            }
+        }
+        self.canvas.update(cx, |workspace, cx| {
+            workspace.toggle_files_panel(cx);
+        });
+    }
+
+    fn save_design(&mut self, _: &SaveDesign, _: &mut Window, cx: &mut Context<Self>) {
+        self.canvas.update(cx, |workspace, cx| {
+            workspace.save_now(cx);
+        });
     }
 
     fn on_key_down(&mut self, event: &KeyDownEvent, window: &mut Window, cx: &mut Context<Self>) {
@@ -110,6 +153,9 @@ impl Render for AppRoot {
             .track_focus(&self.focus_handle)
             .key_context("AppRoot")
             .on_action(cx.listener(Self::toggle_settings))
+            .on_action(cx.listener(Self::new_design))
+            .on_action(cx.listener(Self::toggle_files))
+            .on_action(cx.listener(Self::save_design))
             .on_key_down(cx.listener(Self::on_key_down))
             .child(
                 Routes::new().children([

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -16,6 +16,9 @@ wry = { version = "0.53.3", default-features = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = "0.18"
+gdkx11 = "0.18"
+x11-dl = "2"
+webkit2gtk = { version = "=2.0.1", features = ["v2_38"] }
 
 [dev-dependencies]
 gpui = { workspace = true, features = ["test-support"] }

--- a/crates/ui/src/canvas/linux_key_grab.rs
+++ b/crates/ui/src/canvas/linux_key_grab.rs
@@ -1,0 +1,236 @@
+//! X11 key grabs for Loora shortcuts when the wry WebKit child eats KeyPress.
+//!
+//! After an artboard click, GPUI often stops receiving keyboard events even though
+//! the host toplevel still looks focused. Grabbing Ctrl+N/O/S/K and tool keys on
+//! the Loora window tree and forwarding them over canvas IPC restores shortcuts.
+
+use std::collections::HashSet;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+
+use super::web_canvas::CanvasIpcSender;
+
+/// Start a background X11 grab thread for host file/tool shortcuts.
+pub fn start(window: &impl HasWindowHandle, ipc: CanvasIpcSender) {
+    let Ok(handle) = HasWindowHandle::window_handle(window) else {
+        return;
+    };
+    let xid = match handle.as_raw() {
+        RawWindowHandle::Xlib(h) => h.window as u64,
+        RawWindowHandle::Xcb(h) => h.window.get() as u64,
+        _ => return,
+    };
+    thread::Builder::new()
+        .name("loora-x11-key-grab".into())
+        .spawn(move || grab_loop(xid, ipc))
+        .ok();
+}
+
+fn grab_loop(host_xid: u64, ipc: CanvasIpcSender) {
+    let Ok(xlib) = x11_dl::xlib::Xlib::open() else {
+        return;
+    };
+    unsafe {
+        let display = (xlib.XOpenDisplay)(std::ptr::null());
+        if display.is_null() {
+            return;
+        }
+        let host = host_xid as x11_dl::xlib::Window;
+        let mut grabbed_windows: HashSet<u64> = HashSet::new();
+        let mut last_refresh = Instant::now() - Duration::from_secs(10);
+
+        let refresh_grabs = |grabbed: &mut HashSet<u64>| {
+            let mut targets = vec![host];
+            collect_descendants(&xlib, display, host, &mut targets);
+            for win in targets {
+                let id = win as u64;
+                if grabbed.contains(&id) {
+                    continue;
+                }
+                grab_shortcut_keys(&xlib, display, win);
+                grabbed.insert(id);
+            }
+        };
+        refresh_grabs(&mut grabbed_windows);
+        (xlib.XFlush)(display);
+
+        loop {
+            if last_refresh.elapsed() > Duration::from_secs(2) {
+                refresh_grabs(&mut grabbed_windows);
+                (xlib.XFlush)(display);
+                last_refresh = Instant::now();
+            }
+            if (xlib.XPending)(display) == 0 {
+                thread::sleep(Duration::from_millis(8));
+                continue;
+            }
+            let mut event: x11_dl::xlib::XEvent = std::mem::zeroed();
+            (xlib.XNextEvent)(display, &mut event);
+            if event.get_type() != x11_dl::xlib::KeyPress {
+                continue;
+            }
+            let key_event: x11_dl::xlib::XKeyEvent = event.key;
+            let mut focus: x11_dl::xlib::Window = 0;
+            let mut revert = 0;
+            (xlib.XGetInputFocus)(display, &mut focus, &mut revert);
+            if !focus_belongs_to_host(&xlib, display, host, focus)
+                && !focus_belongs_to_host(&xlib, display, host, key_event.window)
+            {
+                continue;
+            }
+
+            let mut keysym: x11_dl::xlib::KeySym = 0;
+            (xlib.XLookupString)(
+                &mut event.key as *mut _,
+                std::ptr::null_mut(),
+                0,
+                &mut keysym,
+                std::ptr::null_mut(),
+            );
+            let mods = key_event.state;
+            let ctrl_down = mods & x11_dl::xlib::ControlMask != 0;
+            let shift_down = mods & x11_dl::xlib::ShiftMask != 0;
+            // Ignore other modifiers for tool keys.
+            let only_shift_or_none = mods
+                & !(x11_dl::xlib::ShiftMask
+                    | x11_dl::xlib::LockMask
+                    | x11_dl::xlib::Mod2Mask)
+                == 0;
+
+            let ks = keysym;
+            let command = if ctrl_down && !shift_down {
+                match keysym_name(&xlib, ks).as_str() {
+                    "n" | "N" => Some("new"),
+                    "o" | "O" | "k" | "K" => Some("files"),
+                    "s" | "S" => Some("save"),
+                    _ => None,
+                }
+            } else if only_shift_or_none && !ctrl_down {
+                match keysym_name(&xlib, ks).as_str() {
+                    "r" | "R" => Some("tool:r"),
+                    "v" | "V" => Some("tool:v"),
+                    "h" | "H" => Some("tool:h"),
+                    "f" | "F" => Some("tool:f"),
+                    "t" | "T" => Some("tool:t"),
+                    "i" | "I" => Some("tool:i"),
+                    _ => None,
+                }
+            } else {
+                None
+            };
+            let Some(command) = command else {
+                continue;
+            };
+            let payload = format!(r#"{{"type":"command","command":"{command}"}}"#);
+            let _ = ipc.try_send(payload);
+        }
+    }
+}
+
+fn keysym_name(xlib: &x11_dl::xlib::Xlib, keysym: x11_dl::xlib::KeySym) -> String {
+    unsafe {
+        let ptr = (xlib.XKeysymToString)(keysym);
+        if ptr.is_null() {
+            return String::new();
+        }
+        std::ffi::CStr::from_ptr(ptr)
+            .to_string_lossy()
+            .into_owned()
+    }
+}
+
+unsafe fn grab_shortcut_keys(
+    xlib: &x11_dl::xlib::Xlib,
+    display: *mut x11_dl::xlib::Display,
+    win: x11_dl::xlib::Window,
+) {
+    let grab = |key: &str, mods: u32| {
+        let Ok(c) = std::ffi::CString::new(key) else {
+            return;
+        };
+        let keysym = (xlib.XStringToKeysym)(c.as_ptr());
+        if keysym == 0 {
+            return;
+        }
+        let keycode = (xlib.XKeysymToKeycode)(display, keysym);
+        if keycode == 0 {
+            return;
+        }
+        for extra in [0, x11_dl::xlib::Mod2Mask, x11_dl::xlib::LockMask] {
+            (xlib.XGrabKey)(
+                display,
+                keycode as i32,
+                mods | extra,
+                win,
+                1,
+                x11_dl::xlib::GrabModeAsync,
+                x11_dl::xlib::GrabModeAsync,
+            );
+        }
+    };
+    let ctrl = x11_dl::xlib::ControlMask;
+    for key in ["n", "N", "o", "O", "k", "K", "s", "S"] {
+        grab(key, ctrl);
+    }
+    for key in ["r", "R", "v", "V", "h", "H", "f", "F", "t", "T", "i", "I"] {
+        grab(key, 0);
+    }
+}
+
+unsafe fn collect_descendants(
+    xlib: &x11_dl::xlib::Xlib,
+    display: *mut x11_dl::xlib::Display,
+    win: x11_dl::xlib::Window,
+    out: &mut Vec<x11_dl::xlib::Window>,
+) {
+    let mut root = 0;
+    let mut parent = 0;
+    let mut children: *mut x11_dl::xlib::Window = std::ptr::null_mut();
+    let mut n = 0u32;
+    if (xlib.XQueryTree)(display, win, &mut root, &mut parent, &mut children, &mut n) == 0 {
+        return;
+    }
+    if children.is_null() || n == 0 {
+        return;
+    }
+    let slice = std::slice::from_raw_parts(children, n as usize);
+    for &child in slice {
+        out.push(child);
+        collect_descendants(xlib, display, child, out);
+    }
+    (xlib.XFree)(children as *mut _);
+}
+
+unsafe fn focus_belongs_to_host(
+    xlib: &x11_dl::xlib::Xlib,
+    display: *mut x11_dl::xlib::Display,
+    host: x11_dl::xlib::Window,
+    focus: x11_dl::xlib::Window,
+) -> bool {
+    if focus == 0 || focus == 1 {
+        return false;
+    }
+    let mut current = focus;
+    for _ in 0..32 {
+        if current == host {
+            return true;
+        }
+        let mut root = 0;
+        let mut parent = 0;
+        let mut children: *mut x11_dl::xlib::Window = std::ptr::null_mut();
+        let mut n = 0;
+        if (xlib.XQueryTree)(display, current, &mut root, &mut parent, &mut children, &mut n) == 0 {
+            break;
+        }
+        if !children.is_null() {
+            (xlib.XFree)(children as *mut _);
+        }
+        if parent == 0 || parent == root {
+            break;
+        }
+        current = parent;
+    }
+    false
+}

--- a/crates/ui/src/canvas/mod.rs
+++ b/crates/ui/src/canvas/mod.rs
@@ -1,6 +1,8 @@
 mod files;
 mod image_picker;
 mod layers;
+#[cfg(target_os = "linux")]
+mod linux_key_grab;
 mod properties;
 mod text_edit;
 mod web_canvas;

--- a/crates/ui/src/canvas/web_canvas.rs
+++ b/crates/ui/src/canvas/web_canvas.rs
@@ -107,6 +107,8 @@ pub struct CanvasWebView {
     focus_handle: FocusHandle,
     webview: Option<Rc<wry::WebView>>,
     visible: bool,
+    /// When true, skip per-frame `focus_parent` so contenteditable can receive keys.
+    webview_owns_keyboard: Cell<bool>,
     bounds: Bounds<Pixels>,
     applied_bounds: Rc<Cell<Bounds<Pixels>>>,
     viewport_bounds: Rc<Cell<Bounds<Pixels>>>,
@@ -127,11 +129,18 @@ impl CanvasWebView {
 
         let allowed_assets = Rc::new(RefCell::new(HashSet::new()));
         let protocol_assets = allowed_assets.clone();
+        let page_load_sender = ipc_sender.clone();
         let builder = WebViewBuilder::new()
             .with_html(CANVAS_SHELL)
             .with_devtools(cfg!(debug_assertions))
+            .with_focused(false)
             .with_ipc_handler(move |request| {
                 let _ = ipc_sender.try_send(request.body().clone());
+            })
+            .with_on_page_load_handler(move |event, _url| {
+                if matches!(event, wry::PageLoadEvent::Finished) {
+                    let _ = page_load_sender.try_send(r#"{"type":"ready"}"#.to_string());
+                }
             })
             .with_custom_protocol("loora-asset".into(), move |_id, request| {
                 asset_response(request.uri().path(), &protocol_assets.borrow())
@@ -146,6 +155,8 @@ impl CanvasWebView {
                     position: Position::Logical(LogicalPosition::new(0.0, 0.0)),
                     size: WrySize::Logical(LogicalSize::new(1.0, 1.0)),
                 })?;
+                // Prefer host keyboard; pointer still targets the child.
+                let _ = webview.focus_parent();
                 Ok(Rc::new(webview))
             })
             .map_err(|error| {
@@ -159,6 +170,7 @@ impl CanvasWebView {
             focus_handle: cx.focus_handle(),
             webview,
             visible: true,
+            webview_owns_keyboard: Cell::new(false),
             bounds: Bounds::default(),
             applied_bounds: Rc::new(Cell::new(Bounds::default())),
             viewport_bounds,
@@ -292,6 +304,24 @@ impl CanvasWebView {
     pub fn visible(&self) -> bool {
         self.visible
     }
+
+    /// Move keyboard focus off the child webview back to the GPUI host window.
+    pub fn reclaim_host_keyboard(&self) {
+        self.webview_owns_keyboard.set(false);
+        let Some(webview) = self.webview.as_ref() else {
+            return;
+        };
+        let _ = webview.focus_parent();
+    }
+
+    /// Give the child webview keyboard focus (e.g. while editing text).
+    pub fn focus_webview(&self) {
+        self.webview_owns_keyboard.set(true);
+        let Some(webview) = self.webview.as_ref() else {
+            return;
+        };
+        let _ = webview.focus();
+    }
 }
 
 /// Drain pending GTK events. Required so wry visibility/bounds updates apply
@@ -420,6 +450,11 @@ impl CanvasWebViewElement {
     ) -> Self {
         Self { parent, view }
     }
+
+    fn visible_and_should_reclaim_keyboard(&self, cx: &App) -> bool {
+        let parent = self.parent.read(cx);
+        parent.visible() && !parent.webview_owns_keyboard.get()
+    }
 }
 
 impl IntoElement for CanvasWebViewElement {
@@ -505,7 +540,7 @@ impl Element for CanvasWebViewElement {
         _: &mut Self::RequestLayoutState,
         hitbox: &mut Self::PrepaintState,
         window: &mut Window,
-        _: &mut App,
+        cx: &mut App,
     ) {
         #[cfg(target_os = "linux")]
         {
@@ -517,9 +552,18 @@ impl Element for CanvasWebViewElement {
             .as_ref()
             .map(|hitbox| hitbox.bounds)
             .unwrap_or(bounds);
+        // Reclaim GDK/WebKit keyboard every frame so Ctrl+N/R stay on the GPUI
+        // host. Pointer events still hit the child; in-webview text editing
+        // sets `webview_owns_keyboard` via `focus_webview()`.
+        if self.visible_and_should_reclaim_keyboard(cx) {
+            let _ = self.view.focus_parent();
+        }
         window.with_content_mask(Some(ContentMask { bounds }), |window| {
             let webview = self.view.clone();
-            window.on_mouse_event(move |event: &MouseDownEvent, _, _, _| {
+            window.on_mouse_event(move |event: &MouseDownEvent, phase, _, _| {
+                if phase != gpui::DispatchPhase::Bubble {
+                    return;
+                }
                 if !bounds.contains(&event.position) {
                     let _ = webview.focus_parent();
                 }
@@ -814,6 +858,7 @@ html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:
     if (btn.dataset.tool) post('command', { command: `tool:${btn.dataset.tool}` });
     else if (btn.dataset.cmd) post('command', { command: btn.dataset.cmd });
     surface.focus({ preventScroll: true });
+    post('canvas-pointer');
   });
   const emptyCta = document.getElementById('loora-empty-cta');
   const emptyDivider = document.getElementById('loora-empty-divider');
@@ -827,6 +872,7 @@ html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:
     event.stopPropagation();
     post('command', { command: 'fit-selection' });
     surface.focus({ preventScroll: true });
+    post('canvas-pointer');
   });
   const readyTimer = setInterval(() => post('ready'), 250);
   const nodeForId = id => state.nodes.get(id) || null;
@@ -1373,6 +1419,10 @@ html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:
   surface.addEventListener('pointerdown', event => {
     if (event.button !== 0 && event.button !== 1) return;
     surface.focus({ preventScroll:true });
+    // GPUI never receives this click (X11 child). Ask the host to reclaim keys.
+    if (!(event.target instanceof Element && event.target.closest('[data-loora-editing="true"]'))) {
+      post('canvas-pointer');
+    }
     const point = worldPoint(event);
     // Space/middle-button panning outranks handles and tools: it is the escape
     // hatch users reach for while a create tool is armed.
@@ -1661,6 +1711,7 @@ html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:
     if (node.dataset.looraKind === 'text' && node.dataset.looraLocked !== 'true') {
       node.dataset.looraEditing = 'true';
       node.contentEditable = 'plaintext-only';
+      post('webview-editing', { active: true });
       node.focus({ preventScroll:true });
       // Place caret at click instead of selecting all — feels like a real text tool.
       try {
@@ -1712,6 +1763,7 @@ html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:
       post('text', { id:node.dataset.looraNode, text:node.innerText.replace(/\r/g,''), bounds });
       node.removeAttribute('contenteditable');
       node.removeAttribute('data-loora-editing');
+      post('webview-editing', { active: false });
     }
     if (state.preview) {
       const previewNode = targetNode(event.target);
@@ -1784,7 +1836,7 @@ html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:
     const key = event.key.toLowerCase();
     if (mod && key === 'z') command = event.shiftKey ? 'redo' : 'undo';
     else if (mod && key === 'y') command = 'redo';
-    else if (mod && key === 's') command = 'save';
+    // new / files / save: handled by the capture-phase window listener below.
     else if (mod && key === 'c') command = 'copy';
     else if (mod && key === 'x') command = 'cut';
     else if (mod && key === 'v') command = 'paste';
@@ -2078,6 +2130,8 @@ mod tests {
         assert!(CANVAS_SHELL.contains("if (code === 'KeyN') command = 'new';"));
         assert!(CANVAS_SHELL.contains("}, true);"));
         assert!(CANVAS_SHELL.contains("surface.focus({ preventScroll: true });"));
+        assert!(CANVAS_SHELL.contains("post('canvas-pointer')"));
+        assert!(CANVAS_SHELL.contains("post('webview-editing', { active: true })"));
     }
 
     #[test]
@@ -2090,6 +2144,7 @@ mod tests {
         assert!(CANVAS_SHELL.contains(
             "post('command', { command });\n  }, true);"
         ));
+        assert!(CANVAS_SHELL.contains("post('canvas-pointer')"));
     }
 
     #[test]

--- a/crates/ui/src/canvas/web_canvas.rs
+++ b/crates/ui/src/canvas/web_canvas.rs
@@ -130,6 +130,8 @@ impl CanvasWebView {
         let allowed_assets = Rc::new(RefCell::new(HashSet::new()));
         let protocol_assets = allowed_assets.clone();
         let page_load_sender = ipc_sender.clone();
+        #[cfg(target_os = "linux")]
+        let key_grab_sender = ipc_sender.clone();
         let builder = WebViewBuilder::new()
             .with_html(CANVAS_SHELL)
             .with_devtools(cfg!(debug_assertions))
@@ -183,6 +185,9 @@ impl CanvasWebView {
                 error
             })
             .ok();
+
+        #[cfg(target_os = "linux")]
+        crate::canvas::linux_key_grab::start(window, key_grab_sender);
 
         Self {
             focus_handle: cx.focus_handle(),

--- a/crates/ui/src/canvas/web_canvas.rs
+++ b/crates/ui/src/canvas/web_canvas.rs
@@ -107,7 +107,7 @@ pub struct CanvasWebView {
     focus_handle: FocusHandle,
     webview: Option<Rc<wry::WebView>>,
     visible: bool,
-    /// When true, skip per-frame `focus_parent` so contenteditable can receive keys.
+    /// When true, skip reclaim while contenteditable is active on the host-forward path.
     webview_owns_keyboard: Cell<bool>,
     bounds: Bounds<Pixels>,
     applied_bounds: Rc<Cell<Bounds<Pixels>>>,
@@ -318,7 +318,9 @@ impl CanvasWebView {
         let _ = webview.focus_parent();
     }
 
-    /// Give the child webview keyboard focus (e.g. while editing text).
+    /// Give the child webview keyboard focus (platforms where grab_focus delivers keys).
+    /// On Linux X11 embed this is a no-op path — host reclaim + inject-key is used instead.
+    #[allow(dead_code)]
     pub fn focus_webview(&self) {
         self.webview_owns_keyboard.set(true);
         let Some(webview) = self.webview.as_ref() else {
@@ -1419,7 +1421,8 @@ html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:
   surface.addEventListener('pointerdown', event => {
     if (event.button !== 0 && event.button !== 1) return;
     surface.focus({ preventScroll:true });
-    // GPUI never receives this click (X11 child). Ask the host to reclaim keys.
+    // GPUI never receives this click (X11 child). Ask the host to keep/reclaim
+    // keyboard focus — wry grab_focus does not receive X keys on Linux embed.
     if (!(event.target instanceof Element && event.target.closest('[data-loora-editing="true"]'))) {
       post('canvas-pointer');
     }
@@ -2040,6 +2043,45 @@ html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:
       if (command.selection) setSelection(command.selection);
       else syncHandles();
     }
+    else if (command.type === 'inject-key') {
+      const node = document.activeElement instanceof Element
+        ? document.activeElement.closest('[data-loora-editing="true"]')
+        : null;
+      const target = node || scene.querySelector('[data-loora-editing="true"]');
+      if (!target) return;
+      target.focus({ preventScroll:true });
+      if (typeof command.text === 'string' && command.text.length) {
+        try { document.execCommand('insertText', false, command.text); } catch (_) {
+          target.append(document.createTextNode(command.text));
+        }
+        return;
+      }
+      const action = command.action;
+      if (action === 'escape') { target.blur(); return; }
+      if (action === 'enter') {
+        try { document.execCommand('insertText', false, '\n'); } catch (_) {}
+        return;
+      }
+      if (action === 'backspace') {
+        try { document.execCommand('delete'); } catch (_) {}
+        return;
+      }
+      if (action === 'delete') {
+        try { document.execCommand('forwardDelete'); } catch (_) {}
+        return;
+      }
+      // Arrow / home / end: synthesize a key event for the contenteditable.
+      const keyMap = {
+        left: 'ArrowLeft', right: 'ArrowRight', up: 'ArrowUp', down: 'ArrowDown',
+        home: 'Home', end: 'End',
+      };
+      const keyName = keyMap[action];
+      if (!keyName) return;
+      target.dispatchEvent(new KeyboardEvent('keydown', {
+        key: keyName, code: keyName, bubbles: true, cancelable: true,
+        shiftKey: !!command.shift,
+      }));
+    }
     else if (command.type === 'state') {
       state.camera = { ...state.camera, ...(command.camera || {}) };
       state.tool = command.tool || 'select';
@@ -2163,6 +2205,8 @@ mod tests {
         assert!(CANVAS_SHELL.contains("post('canvas-pointer')"));
         assert!(CANVAS_SHELL.contains("post('webview-editing', { active: true })"));
         assert!(CANVAS_SHELL.contains("post('webview-editing', { active: false })"));
+        assert!(CANVAS_SHELL.contains("command.type === 'inject-key'"));
+        assert!(CANVAS_SHELL.contains("document.execCommand('insertText'"));
     }
 
     #[test]

--- a/crates/ui/src/canvas/web_canvas.rs
+++ b/crates/ui/src/canvas/web_canvas.rs
@@ -25,6 +25,8 @@ use wry::{
     http::{header::CONTENT_TYPE, Response},
     Rect, WebViewBuilder,
 };
+#[cfg(windows)]
+use wry::WebViewBuilderExtWindows;
 
 pub type CanvasIpcSender = async_channel::Sender<String>;
 
@@ -125,7 +127,7 @@ impl CanvasWebView {
 
         let allowed_assets = Rc::new(RefCell::new(HashSet::new()));
         let protocol_assets = allowed_assets.clone();
-        let webview = WebViewBuilder::new()
+        let builder = WebViewBuilder::new()
             .with_html(CANVAS_SHELL)
             .with_devtools(cfg!(debug_assertions))
             .with_ipc_handler(move |request| {
@@ -133,7 +135,11 @@ impl CanvasWebView {
             })
             .with_custom_protocol("loora-asset".into(), move |_id, request| {
                 asset_response(request.uri().path(), &protocol_assets.borrow())
-            })
+            });
+        // WebView2 treats Ctrl+N/O/S as browser chrome accelerators unless disabled.
+        #[cfg(windows)]
+        let builder = builder.with_browser_accelerator_keys(false);
+        let webview = builder
             .build_as_child(&WryParent(window))
             .and_then(|webview| {
                 webview.set_bounds(Rect {
@@ -791,7 +797,13 @@ html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:
     if (!contextMenu.hidden && !contextMenu.contains(event.target)) hideContextMenu();
   }, true);
   window.addEventListener('blur', hideContextMenu);
+  // Keep keyboard focus on the surface: toolbar/zoom clicks must not steal it or
+  // surface-only shortcuts (R, ⌘Z, …) stop working after chrome interaction.
+  document.querySelectorAll('#loora-toolbar button, #loora-zoom').forEach(el => {
+    el.tabIndex = -1;
+  });
   document.getElementById('loora-toolbar')?.addEventListener('pointerdown', event => {
+    event.preventDefault();
     event.stopPropagation();
   });
   document.getElementById('loora-toolbar')?.addEventListener('click', event => {
@@ -801,15 +813,20 @@ html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:
     event.stopPropagation();
     if (btn.dataset.tool) post('command', { command: `tool:${btn.dataset.tool}` });
     else if (btn.dataset.cmd) post('command', { command: btn.dataset.cmd });
+    surface.focus({ preventScroll: true });
   });
   const emptyCta = document.getElementById('loora-empty-cta');
   const emptyDivider = document.getElementById('loora-empty-divider');
   const emptyLabel = document.getElementById('loora-empty-label');
-  zoomChip?.addEventListener('pointerdown', event => event.stopPropagation());
+  zoomChip?.addEventListener('pointerdown', event => {
+    event.preventDefault();
+    event.stopPropagation();
+  });
   zoomChip?.addEventListener('click', event => {
     event.preventDefault();
     event.stopPropagation();
     post('command', { command: 'fit-selection' });
+    surface.focus({ preventScroll: true });
   });
   const readyTimer = setInterval(() => post('ready'), 250);
   const nodeForId = id => state.nodes.get(id) || null;
@@ -1782,32 +1799,32 @@ html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:
     else if (mod && key === '0') command = 'zoom-reset';
     else if (mod && key === '1') command = 'fit-selection';
     else if (mod && key === '2') command = 'fit-all';
-    else if (mod && (key === 'k' || key === 'o')) command = 'files';
-    else if (mod && key === 'n') command = 'new';
     else if (event.key === 'Delete' || event.key === 'Backspace') command = 'delete';
     else if (event.key === 'Escape') command = 'escape';
     else if (!mod && !event.altKey && event.key.startsWith('Arrow')) command = `nudge:${event.key.slice(5).toLowerCase()}:${event.shiftKey ? 10 : 1}`;
     else if (!mod && !event.altKey && ['v','h','f','t','r','i'].includes(key)) command = `tool:${key}`;
     if (command) { event.preventDefault(); post('command', { command }); }
   });
-  // File shortcuts must work even when `#loora-surface` is not the active DOM
-  // focus target (common after chrome clicks). GPUI still handles these when the
-  // wry child does not own keyboard focus.
+  // File shortcuts via capture so GTK/WebKit (and WebView2) cannot claim Ctrl+N/O/S
+  // before JS, and so they still fire when focus is not on `#loora-surface`.
+  // GPUI bindings cover the same chords when the wry child does not own focus.
   window.addEventListener('keydown', event => {
     if (event.defaultPrevented) return;
     const editing = event.target instanceof Element && !!event.target.closest('[data-loora-editing="true"]');
     if (editing) return;
     const mod = event.metaKey || event.ctrlKey;
     if (!mod) return;
-    const key = event.key.toLowerCase();
+    // Prefer `code` so layout remaps under Ctrl still match physical N/O/K/S.
+    const code = event.code;
     let command = null;
-    if (key === 'n') command = 'new';
-    else if (key === 'o' || key === 'k') command = 'files';
-    else if (key === 's') command = 'save';
+    if (code === 'KeyN') command = 'new';
+    else if (code === 'KeyO' || code === 'KeyK') command = 'files';
+    else if (code === 'KeyS') command = 'save';
     if (!command) return;
     event.preventDefault();
+    event.stopPropagation();
     post('command', { command });
-  });
+  }, true);
   surface.addEventListener('keyup', event => {
     if (event.code === 'Space') setSpacePan(false);
   });
@@ -2057,8 +2074,22 @@ mod tests {
         assert!(CANVAS_SHELL.contains(">Draw · R</button>"));
         assert!(CANVAS_SHELL.contains("syncEmptyHints()"));
         assert!(CANVAS_SHELL.contains("#loora-surface{position:absolute;inset:0;z-index:0"));
-        assert!(CANVAS_SHELL.contains("else if (mod && key === 'n') command = 'new';"));
-        assert!(CANVAS_SHELL.contains("if (key === 'n') command = 'new';"));
+        assert!(CANVAS_SHELL.contains("el.tabIndex = -1"));
+        assert!(CANVAS_SHELL.contains("if (code === 'KeyN') command = 'new';"));
+        assert!(CANVAS_SHELL.contains("}, true);"));
+        assert!(CANVAS_SHELL.contains("surface.focus({ preventScroll: true });"));
+    }
+
+    #[test]
+    fn webview_file_shortcuts_use_capture_phase() {
+        assert!(CANVAS_SHELL.contains("if (code === 'KeyN') command = 'new';"));
+        assert!(CANVAS_SHELL.contains("else if (code === 'KeyO' || code === 'KeyK') command = 'files';"));
+        assert!(CANVAS_SHELL.contains("else if (code === 'KeyS') command = 'save';"));
+        assert!(CANVAS_SHELL.contains("event.stopPropagation();"));
+        // Capture listener must be registered with the capture flag.
+        assert!(CANVAS_SHELL.contains(
+            "post('command', { command });\n  }, true);"
+        ));
     }
 
     #[test]

--- a/crates/ui/src/canvas/web_canvas.rs
+++ b/crates/ui/src/canvas/web_canvas.rs
@@ -305,6 +305,10 @@ impl CanvasWebView {
         self.visible
     }
 
+    pub fn set_webview_owns_keyboard(&self, owns: bool) {
+        self.webview_owns_keyboard.set(owns);
+    }
+
     /// Move keyboard focus off the child webview back to the GPUI host window.
     pub fn reclaim_host_keyboard(&self) {
         self.webview_owns_keyboard.set(false);
@@ -450,11 +454,6 @@ impl CanvasWebViewElement {
     ) -> Self {
         Self { parent, view }
     }
-
-    fn visible_and_should_reclaim_keyboard(&self, cx: &App) -> bool {
-        let parent = self.parent.read(cx);
-        parent.visible() && !parent.webview_owns_keyboard.get()
-    }
 }
 
 impl IntoElement for CanvasWebViewElement {
@@ -552,23 +551,24 @@ impl Element for CanvasWebViewElement {
             .as_ref()
             .map(|hitbox| hitbox.bounds)
             .unwrap_or(bounds);
-        // Reclaim GDK/WebKit keyboard every frame so Ctrl+N/R stay on the GPUI
-        // host. Pointer events still hit the child; in-webview text editing
-        // sets `webview_owns_keyboard` via `focus_webview()`.
-        if self.visible_and_should_reclaim_keyboard(cx) {
-            let _ = self.view.focus_parent();
-        }
+        // Do not steal keyboard every frame — canvas shortcuts run in JS while the
+        // child owns focus. Only reclaim when the pointer hits GPUI chrome.
         window.with_content_mask(Some(ContentMask { bounds }), |window| {
             let webview = self.view.clone();
-            window.on_mouse_event(move |event: &MouseDownEvent, phase, _, _| {
+            let parent = self.parent.clone();
+            window.on_mouse_event(move |event: &MouseDownEvent, phase, _window, cx| {
                 if phase != gpui::DispatchPhase::Bubble {
                     return;
                 }
                 if !bounds.contains(&event.position) {
                     let _ = webview.focus_parent();
+                    parent.update(cx, |view, _| {
+                        view.set_webview_owns_keyboard(false);
+                    });
                 }
             });
         });
+        let _ = cx;
     }
 }
 
@@ -1857,21 +1857,37 @@ html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:
     else if (!mod && !event.altKey && ['v','h','f','t','r','i'].includes(key)) command = `tool:${key}`;
     if (command) { event.preventDefault(); post('command', { command }); }
   });
-  // File shortcuts via capture so GTK/WebKit (and WebView2) cannot claim Ctrl+N/O/S
-  // before JS, and so they still fire when focus is not on `#loora-surface`.
-  // GPUI bindings cover the same chords when the wry child does not own focus.
+  // Canvas shortcuts via capture so they work whenever the webview has keyboard
+  // focus (surface, toolbar sibling, or body) — including after artboard clicks.
   window.addEventListener('keydown', event => {
     if (event.defaultPrevented) return;
     const editing = event.target instanceof Element && !!event.target.closest('[data-loora-editing="true"]');
     if (editing) return;
+    if (!contextMenu.hidden) return;
     const mod = event.metaKey || event.ctrlKey;
-    if (!mod) return;
-    // Prefer `code` so layout remaps under Ctrl still match physical N/O/K/S.
     const code = event.code;
+    const key = event.key.toLowerCase();
     let command = null;
-    if (code === 'KeyN') command = 'new';
-    else if (code === 'KeyO' || code === 'KeyK') command = 'files';
-    else if (code === 'KeyS') command = 'save';
+    if (mod && code === 'KeyN') command = 'new';
+    else if (mod && (code === 'KeyO' || code === 'KeyK')) command = 'files';
+    else if (mod && code === 'KeyS') command = 'save';
+    else if (mod && code === 'KeyZ') command = event.shiftKey ? 'redo' : 'undo';
+    else if (mod && code === 'KeyY') command = 'redo';
+    else if (mod && code === 'KeyC') command = 'copy';
+    else if (mod && code === 'KeyX') command = 'cut';
+    else if (mod && code === 'KeyV') command = 'paste';
+    else if (mod && code === 'KeyD') command = 'duplicate';
+    else if (mod && code === 'KeyA') command = 'select-all';
+    else if (mod && code === 'KeyL') command = 'lock';
+    else if (mod && code === 'KeyG') command = event.shiftKey ? 'ungroup' : 'group';
+    else if (mod && (code === 'Equal' || code === 'NumpadAdd')) command = 'zoom-in';
+    else if (mod && (code === 'Minus' || code === 'NumpadSubtract')) command = 'zoom-out';
+    else if (mod && code === 'Digit0') command = 'zoom-reset';
+    else if (mod && code === 'Digit1') command = 'fit-selection';
+    else if (mod && code === 'Digit2') command = 'fit-all';
+    else if (!mod && !event.altKey && ['v','h','f','t','r','i'].includes(key)) command = `tool:${key}`;
+    else if (event.key === 'Delete' || event.key === 'Backspace') command = 'delete';
+    else if (event.key === 'Escape') command = 'escape';
     if (!command) return;
     event.preventDefault();
     event.stopPropagation();
@@ -2127,7 +2143,7 @@ mod tests {
         assert!(CANVAS_SHELL.contains("syncEmptyHints()"));
         assert!(CANVAS_SHELL.contains("#loora-surface{position:absolute;inset:0;z-index:0"));
         assert!(CANVAS_SHELL.contains("el.tabIndex = -1"));
-        assert!(CANVAS_SHELL.contains("if (code === 'KeyN') command = 'new';"));
+        assert!(CANVAS_SHELL.contains("if (mod && code === 'KeyN') command = 'new';"));
         assert!(CANVAS_SHELL.contains("}, true);"));
         assert!(CANVAS_SHELL.contains("surface.focus({ preventScroll: true });"));
         assert!(CANVAS_SHELL.contains("post('canvas-pointer')"));
@@ -2136,15 +2152,17 @@ mod tests {
 
     #[test]
     fn webview_file_shortcuts_use_capture_phase() {
-        assert!(CANVAS_SHELL.contains("if (code === 'KeyN') command = 'new';"));
-        assert!(CANVAS_SHELL.contains("else if (code === 'KeyO' || code === 'KeyK') command = 'files';"));
-        assert!(CANVAS_SHELL.contains("else if (code === 'KeyS') command = 'save';"));
+        assert!(CANVAS_SHELL.contains("if (mod && code === 'KeyN') command = 'new';"));
+        assert!(CANVAS_SHELL.contains("else if (mod && (code === 'KeyO' || code === 'KeyK')) command = 'files';"));
+        assert!(CANVAS_SHELL.contains("else if (mod && code === 'KeyS') command = 'save';"));
+        assert!(CANVAS_SHELL.contains("command = `tool:${key}`"));
         assert!(CANVAS_SHELL.contains("event.stopPropagation();"));
-        // Capture listener must be registered with the capture flag.
         assert!(CANVAS_SHELL.contains(
             "post('command', { command });\n  }, true);"
         ));
         assert!(CANVAS_SHELL.contains("post('canvas-pointer')"));
+        assert!(CANVAS_SHELL.contains("post('webview-editing', { active: true })"));
+        assert!(CANVAS_SHELL.contains("post('webview-editing', { active: false })"));
     }
 
     #[test]

--- a/crates/ui/src/canvas/web_canvas.rs
+++ b/crates/ui/src/canvas/web_canvas.rs
@@ -155,8 +155,12 @@ impl CanvasWebView {
                     position: Position::Logical(LogicalPosition::new(0.0, 0.0)),
                     size: WrySize::Logical(LogicalSize::new(1.0, 1.0)),
                 })?;
-                // Prefer host keyboard; pointer still targets the child.
-                let _ = webview.focus_parent();
+                // Prefer host keyboard on platforms where focus_parent is the real host.
+                // On Linux this would focus the child GTK container and steal X keys.
+                #[cfg(not(target_os = "linux"))]
+                {
+                    let _ = webview.focus_parent();
+                }
                 Ok(Rc::new(webview))
             })
             .map_err(|error| {
@@ -315,7 +319,17 @@ impl CanvasWebView {
         let Some(webview) = self.webview.as_ref() else {
             return;
         };
-        let _ = webview.focus_parent();
+        // On Linux X11 embed, wry's parent_window is the child container GTK
+        // window — focusing it steals X keyboard away from GPUI and keys vanish.
+        // Only call focus_parent on platforms where the parent is the real host.
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = webview.focus_parent();
+        }
+        #[cfg(target_os = "linux")]
+        {
+            let _ = webview;
+        }
     }
 
     /// Give the child webview keyboard focus (platforms where grab_focus delivers keys).
@@ -340,7 +354,10 @@ pub fn pump_linux_canvas() {
 }
 
 fn collapse_webview(webview: &wry::WebView) {
-    let _ = webview.focus_parent();
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = webview.focus_parent();
+    }
     let _ = webview.set_visible(false);
     let _ = webview.set_bounds(Rect {
         position: Position::Logical(LogicalPosition::new(-10_000.0, -10_000.0)),
@@ -553,8 +570,8 @@ impl Element for CanvasWebViewElement {
             .as_ref()
             .map(|hitbox| hitbox.bounds)
             .unwrap_or(bounds);
-        // Do not steal keyboard every frame — canvas shortcuts run in JS while the
-        // child owns focus. Only reclaim when the pointer hits GPUI chrome.
+        // Do not steal keyboard every frame — canvas shortcuts run on the host
+        // after canvas-pointer reclaim. Only clear the owns flag on chrome clicks.
         window.with_content_mask(Some(ContentMask { bounds }), |window| {
             let webview = self.view.clone();
             let parent = self.parent.clone();
@@ -563,7 +580,16 @@ impl Element for CanvasWebViewElement {
                     return;
                 }
                 if !bounds.contains(&event.position) {
-                    let _ = webview.focus_parent();
+                    // Linux: do not focus_parent (child GTK window). GPUI already
+                    // has this click; just clear the owns flag.
+                    #[cfg(not(target_os = "linux"))]
+                    {
+                        let _ = webview.focus_parent();
+                    }
+                    #[cfg(target_os = "linux")]
+                    {
+                        let _ = &webview;
+                    }
                     parent.update(cx, |view, _| {
                         view.set_webview_owns_keyboard(false);
                     });

--- a/crates/ui/src/canvas/web_canvas.rs
+++ b/crates/ui/src/canvas/web_canvas.rs
@@ -161,6 +161,20 @@ impl CanvasWebView {
                 {
                     let _ = webview.focus_parent();
                 }
+                // Keep WebKit from taking GTK/X keyboard focus after artboard clicks.
+                #[cfg(target_os = "linux")]
+                {
+                    use gtk::prelude::WidgetExt;
+                    use wry::WebViewExtUnix;
+                    let gtk_wv = webview.webview();
+                    gtk_wv.set_can_focus(false);
+                    if let Some(top) = gtk_wv.toplevel() {
+                        top.set_can_focus(false);
+                    }
+                    // Mark the embed container as non-focusable at the X level so
+                    // clicks do not move X input focus off the GPUI toplevel.
+                    disable_x11_input_focus_for_gtk_widget(&gtk_wv);
+                }
                 Ok(Rc::new(webview))
             })
             .map_err(|error| {
@@ -350,6 +364,38 @@ impl CanvasWebView {
 pub fn pump_linux_canvas() {
     while gtk::events_pending() {
         gtk::main_iteration_do(false);
+    }
+}
+
+/// Clear the X11 InputHint on the WebKit embed window so button presses do not
+/// move keyboard focus away from the GPUI host toplevel.
+#[cfg(target_os = "linux")]
+fn disable_x11_input_focus_for_gtk_widget(widget: &impl gtk::prelude::WidgetExt) {
+    use gtk::gdk::prelude::*;
+    let Some(gdk_window) = widget.window() else {
+        widget.connect_realize(|w| {
+            disable_x11_input_focus_for_gtk_widget(w);
+        });
+        return;
+    };
+    let Some(x11_window) = gdk_window.downcast_ref::<gdkx11::X11Window>() else {
+        return;
+    };
+    let xid = x11_window.xid();
+    let Ok(xlib_lib) = x11_dl::xlib::Xlib::open() else {
+        return;
+    };
+    unsafe {
+        let display = (xlib_lib.XOpenDisplay)(std::ptr::null());
+        if display.is_null() {
+            return;
+        }
+        let mut hints: x11_dl::xlib::XWMHints = std::mem::zeroed();
+        hints.flags = x11_dl::xlib::InputHint;
+        hints.input = 0; // False — do not accept keyboard focus
+        (xlib_lib.XSetWMHints)(display, xid as _, &mut hints);
+        (xlib_lib.XFlush)(display);
+        (xlib_lib.XCloseDisplay)(display);
     }
 }
 
@@ -869,8 +915,8 @@ html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:
     if (!contextMenu.hidden && !contextMenu.contains(event.target)) hideContextMenu();
   }, true);
   window.addEventListener('blur', hideContextMenu);
-  // Keep keyboard focus on the surface: toolbar/zoom clicks must not steal it or
-  // surface-only shortcuts (R, ⌘Z, …) stop working after chrome interaction.
+  // Toolbar/zoom are not focusable — keep X11 keyboard on the GPUI host.
+  // Do not call surface.focus(): WebKit grab_focus steals keys from the embed host.
   document.querySelectorAll('#loora-toolbar button, #loora-zoom').forEach(el => {
     el.tabIndex = -1;
   });
@@ -885,7 +931,6 @@ html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:
     event.stopPropagation();
     if (btn.dataset.tool) post('command', { command: `tool:${btn.dataset.tool}` });
     else if (btn.dataset.cmd) post('command', { command: btn.dataset.cmd });
-    surface.focus({ preventScroll: true });
     post('canvas-pointer');
   });
   const emptyCta = document.getElementById('loora-empty-cta');
@@ -899,7 +944,6 @@ html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:
     event.preventDefault();
     event.stopPropagation();
     post('command', { command: 'fit-selection' });
-    surface.focus({ preventScroll: true });
     post('canvas-pointer');
   });
   const readyTimer = setInterval(() => post('ready'), 250);
@@ -1446,9 +1490,8 @@ html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:
 
   surface.addEventListener('pointerdown', event => {
     if (event.button !== 0 && event.button !== 1) return;
-    surface.focus({ preventScroll:true });
-    // GPUI never receives this click (X11 child). Ask the host to keep/reclaim
-    // keyboard focus — wry grab_focus does not receive X keys on Linux embed.
+    // Do not surface.focus() — on Linux X11 embed that makes WebKit steal
+    // keyboard from the GPUI host so Ctrl+N/tools die after artboard clicks.
     if (!(event.target instanceof Element && event.target.closest('[data-loora-editing="true"]'))) {
       post('canvas-pointer');
     }
@@ -2069,6 +2112,10 @@ html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:
       if (command.selection) setSelection(command.selection);
       else syncHandles();
     }
+    else if (command.type === 'blur-surface') {
+      try { if (document.activeElement && document.activeElement !== document.body) document.activeElement.blur(); } catch (_) {}
+      try { surface.blur(); } catch (_) {}
+    }
     else if (command.type === 'inject-key') {
       const node = document.activeElement instanceof Element
         ? document.activeElement.closest('[data-loora-editing="true"]')
@@ -2213,7 +2260,9 @@ mod tests {
         assert!(CANVAS_SHELL.contains("el.tabIndex = -1"));
         assert!(CANVAS_SHELL.contains("if (mod && code === 'KeyN') command = 'new';"));
         assert!(CANVAS_SHELL.contains("}, true);"));
-        assert!(CANVAS_SHELL.contains("surface.focus({ preventScroll: true });"));
+        // surface.focus steals X keys from the GPUI host on Linux embed.
+        assert!(!CANVAS_SHELL.contains("surface.focus({ preventScroll: true });"));
+        assert!(!CANVAS_SHELL.contains("surface.focus({ preventScroll:true });"));
         assert!(CANVAS_SHELL.contains("post('canvas-pointer')"));
         assert!(CANVAS_SHELL.contains("post('webview-editing', { active: true })"));
     }

--- a/crates/ui/src/canvas/web_canvas.rs
+++ b/crates/ui/src/canvas/web_canvas.rs
@@ -617,7 +617,7 @@ html[data-chrome="light"]{
   --loora-toolbar-shadow:0 8px 28px rgba(0,0,0,.12);
 }
 html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:var(--loora-surface-bg);color:var(--loora-surface-fg)}
-#loora-surface{position:absolute;inset:0;overflow:hidden;touch-action:none;outline:none;background:var(--loora-surface-bg)}
+#loora-surface{position:absolute;inset:0;z-index:0;overflow:hidden;touch-action:none;outline:none;background:var(--loora-surface-bg)}
 /* Toolbar/zoom are peers of the surface — never a full-screen overlay above it.
    A full-bleed chrome layer (even with pointer-events:none) broke hit-testing for
    move/resize in the WKWebView. */
@@ -632,6 +632,12 @@ html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:
 #loora-toolbar [data-tip]:hover::after{content:attr(data-tip);position:absolute;left:50%;bottom:calc(100% + 8px);transform:translateX(-50%);white-space:nowrap;padding:0 8px;height:24px;line-height:24px;border-radius:7px;border:1px solid var(--loora-toolbar-border);background:var(--loora-toolbar-tip-bg);color:var(--loora-toolbar-tip-fg);font:500 11px/24px -apple-system,BlinkMacSystemFont,sans-serif;pointer-events:none;z-index:2;box-shadow:var(--loora-toolbar-shadow)}
 #loora-zoom{position:absolute;right:16px;bottom:16px;height:28px;padding:0 10px;border-radius:7px;border:1px solid var(--loora-toolbar-border);background:var(--loora-toolbar-bg);color:var(--loora-toolbar-fg);font:500 11px/26px -apple-system,BlinkMacSystemFont,sans-serif;cursor:pointer;z-index:50;pointer-events:auto;box-shadow:var(--loora-toolbar-shadow)}
 #loora-zoom:hover{color:var(--loora-toolbar-active-fg)}
+#loora-empty-label{position:absolute;left:50%;bottom:62px;transform:translateX(-50%);z-index:50;pointer-events:none;font:500 12px/1 -apple-system,BlinkMacSystemFont,sans-serif;color:color-mix(in srgb,var(--loora-surface-fg) 48%,transparent);letter-spacing:.01em;user-select:none}
+#loora-empty-label[hidden]{display:none}
+#loora-toolbar .loora-empty-cta{height:28px;padding:0 10px;width:auto;min-width:0;border:1px solid var(--loora-toolbar-border);border-radius:8px;background:var(--loora-toolbar-hover);color:var(--loora-toolbar-fg);font:500 11px/26px -apple-system,BlinkMacSystemFont,sans-serif;cursor:pointer}
+#loora-toolbar .loora-empty-cta:hover{color:var(--loora-toolbar-active-fg)}
+#loora-toolbar .loora-empty-cta[hidden],#loora-empty-divider[hidden]{display:none}
+.loora-preview #loora-empty-label,.loora-preview #loora-empty-cta,.loora-preview #loora-empty-divider{display:none}
 #loora-context-menu[hidden]{display:none}
 #loora-context-menu{position:fixed;z-index:100;min-width:220px;max-height:calc(100vh - 16px);padding:6px;border:1px solid var(--loora-toolbar-border);border-radius:10px;background:var(--loora-toolbar-bg);box-shadow:var(--loora-toolbar-shadow);backdrop-filter:blur(16px);overflow:auto;box-sizing:border-box;font:500 12px/1 -apple-system,BlinkMacSystemFont,sans-serif}
 .loora-context-item{display:flex;align-items:center;justify-content:space-between;width:100%;height:32px;padding:0 10px;border:0;border-radius:7px;background:transparent;color:var(--loora-toolbar-fg);font:inherit;text-align:left;cursor:default}
@@ -641,12 +647,6 @@ html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:
 .loora-context-item.is-destructive{color:#ff6b72}
 .loora-context-shortcut{margin-left:24px;color:color-mix(in srgb,var(--loora-toolbar-fg) 62%,transparent);font-size:11px}
 .loora-context-separator{height:1px;margin:4px 8px;background:var(--loora-toolbar-border)}
-#loora-empty{position:absolute;left:50%;top:46%;transform:translate(-50%,-50%);display:flex;flex-direction:column;align-items:center;gap:10px;z-index:50;pointer-events:auto;user-select:none}
-#loora-empty[hidden]{display:none}
-#loora-empty .loora-empty-copy{font:500 13px/1.2 -apple-system,BlinkMacSystemFont,sans-serif;color:color-mix(in srgb,var(--loora-surface-fg) 45%,transparent);letter-spacing:.01em;pointer-events:none}
-#loora-empty .loora-empty-cta{pointer-events:auto;height:28px;padding:0 12px;border-radius:8px;border:1px solid var(--loora-toolbar-border);background:var(--loora-toolbar-bg);color:var(--loora-toolbar-fg);font:500 12px/26px -apple-system,BlinkMacSystemFont,sans-serif;cursor:pointer;box-shadow:var(--loora-toolbar-shadow)}
-#loora-empty .loora-empty-cta:hover{background:var(--loora-toolbar-hover);color:var(--loora-toolbar-active-fg)}
-.loora-preview #loora-empty{display:none}
 </style>
 <style id="loora-document-css"></style>
 </head>
@@ -669,12 +669,11 @@ html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:
       <div class="loora-divider"></div>
       <button type="button" class="loora-action" data-cmd="undo" data-tip="Undo  ⌘Z" id="loora-undo"><svg viewBox="0 0 24 24" fill="none"><path d="M4 10h10a5 5 0 1 1 0 10H9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M8 6 4 10l4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
       <button type="button" class="loora-action" data-cmd="redo" data-tip="Redo  ⌘⇧Z" id="loora-redo"><svg viewBox="0 0 24 24" fill="none"><path d="M20 10H10a5 5 0 1 0 0 10h5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="m16 6 4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+      <div class="loora-divider" id="loora-empty-divider" hidden></div>
+      <button type="button" class="loora-empty-cta" id="loora-empty-cta" data-tool="rectangle" hidden>Draw · R</button>
   </div>
   <button type="button" id="loora-zoom" data-cmd="fit-selection">100%</button>
-  <div id="loora-empty" hidden>
-    <div class="loora-empty-copy">Empty frame</div>
-    <button type="button" class="loora-empty-cta" data-tool="rectangle">Draw a rectangle · R</button>
-  </div>
+  <div id="loora-empty-label" hidden>Empty frame</div>
   <div id="loora-context-menu" role="menu" hidden></div>
 </div>
 <script>
@@ -803,17 +802,9 @@ html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:
     if (btn.dataset.tool) post('command', { command: `tool:${btn.dataset.tool}` });
     else if (btn.dataset.cmd) post('command', { command: btn.dataset.cmd });
   });
-  const emptyHost = document.getElementById('loora-empty');
-  emptyHost?.addEventListener('pointerdown', event => {
-    event.stopPropagation();
-  });
-  emptyHost?.addEventListener('click', event => {
-    const btn = event.target.closest('[data-tool]');
-    if (!btn) return;
-    event.preventDefault();
-    event.stopPropagation();
-    post('command', { command: `tool:${btn.dataset.tool}` });
-  });
+  const emptyCta = document.getElementById('loora-empty-cta');
+  const emptyDivider = document.getElementById('loora-empty-divider');
+  const emptyLabel = document.getElementById('loora-empty-label');
   zoomChip?.addEventListener('pointerdown', event => event.stopPropagation());
   zoomChip?.addEventListener('click', event => {
     event.preventDefault();
@@ -1799,6 +1790,24 @@ html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:
     else if (!mod && !event.altKey && ['v','h','f','t','r','i'].includes(key)) command = `tool:${key}`;
     if (command) { event.preventDefault(); post('command', { command }); }
   });
+  // File shortcuts must work even when `#loora-surface` is not the active DOM
+  // focus target (common after chrome clicks). GPUI still handles these when the
+  // wry child does not own keyboard focus.
+  window.addEventListener('keydown', event => {
+    if (event.defaultPrevented) return;
+    const editing = event.target instanceof Element && !!event.target.closest('[data-loora-editing="true"]');
+    if (editing) return;
+    const mod = event.metaKey || event.ctrlKey;
+    if (!mod) return;
+    const key = event.key.toLowerCase();
+    let command = null;
+    if (key === 'n') command = 'new';
+    else if (key === 'o' || key === 'k') command = 'files';
+    else if (key === 's') command = 'save';
+    if (!command) return;
+    event.preventDefault();
+    post('command', { command });
+  });
   surface.addEventListener('keyup', event => {
     if (event.code === 'Space') setSpacePan(false);
   });
@@ -1821,14 +1830,11 @@ html,body,#loora-app{width:100%;height:100%;margin:0;overflow:hidden;background:
     cameraTransform(); queueCamera();
   };
   const syncEmptyHints = () => {
-    if (!emptyHost) return;
-    if (state.preview) {
-      emptyHost.hidden = true;
-      return;
-    }
     const hosts = [...scene.querySelectorAll('.loora-page-host:not([data-loora-overlay-page])')];
-    const empty = hosts.some(host => !host.querySelector('[data-loora-node]:not([data-loora-root])'));
-    emptyHost.hidden = !empty;
+    const empty = !state.preview && hosts.some(host => !host.querySelector('[data-loora-node]:not([data-loora-root])'));
+    if (emptyCta) emptyCta.hidden = !empty;
+    if (emptyDivider) emptyDivider.hidden = !empty;
+    if (emptyLabel) emptyLabel.hidden = !empty;
   };
   const focusPage = id => {
     const node = nodeForId(id); if (!node) return;
@@ -2043,13 +2049,16 @@ mod tests {
 
     #[test]
     fn webview_empty_frame_shows_cta() {
-        assert!(CANVAS_SHELL.contains("id=\"loora-empty\""));
+        assert!(CANVAS_SHELL.contains("id=\"loora-empty-cta\""));
+        assert!(CANVAS_SHELL.contains("id=\"loora-empty-label\""));
         assert!(CANVAS_SHELL.contains("const syncEmptyHints"));
         assert!(CANVAS_SHELL.contains("Empty frame"));
         assert!(CANVAS_SHELL.contains("[data-loora-node]:not([data-loora-root])"));
-        assert!(CANVAS_SHELL.contains("Draw a rectangle · R"));
+        assert!(CANVAS_SHELL.contains(">Draw · R</button>"));
         assert!(CANVAS_SHELL.contains("syncEmptyHints()"));
-        assert!(CANVAS_SHELL.contains(".loora-preview #loora-empty{display:none}"));
+        assert!(CANVAS_SHELL.contains("#loora-surface{position:absolute;inset:0;z-index:0"));
+        assert!(CANVAS_SHELL.contains("else if (mod && key === 'n') command = 'new';"));
+        assert!(CANVAS_SHELL.contains("if (key === 'n') command = 'new';"));
     }
 
     #[test]

--- a/crates/ui/src/canvas/workspace.rs
+++ b/crates/ui/src/canvas/workspace.rs
@@ -430,12 +430,14 @@ impl CanvasWorkspace {
         self.webview.update(cx, |view, _| {
             view.reclaim_host_keyboard();
         });
-        if !window.is_window_active() {
-            window.activate_window();
-        }
-        if !self.focus_handle.is_focused(window) {
-            self.focus_handle.focus(window, cx);
-        }
+        // Always re-activate: after a wry child click the window may still report
+        // active while X keyboard focus is stuck on the embed container.
+        window.activate_window();
+        self.focus_handle.focus(window, cx);
+        eprintln!(
+            "loora: host keyboard reclaim (focused={})",
+            self.focus_handle.is_focused(window)
+        );
     }
 
     fn shell_chrome_token(&self) -> ShellChromeToken {

--- a/crates/ui/src/canvas/workspace.rs
+++ b/crates/ui/src/canvas/workspace.rs
@@ -144,6 +144,7 @@ pub struct CanvasWorkspace {
     pub(crate) viewport_bounds: Rc<Cell<Bounds<Pixels>>>,
     webview: Entity<CanvasWebView>,
     _web_ipc_task: Option<Task<()>>,
+    _keyboard_reclaim_task: Option<Task<()>>,
     web_document_key: Option<WebDocumentKey>,
     web_state_key: Option<WebStateKey>,
     web_ready: bool,
@@ -224,6 +225,10 @@ pub struct CanvasWorkspace {
     /// Inspector breakpoint (None = base). Canvas still paints base layout.
     pub(crate) active_breakpoint_id: Option<String>,
     focus_handle: FocusHandle,
+    /// Webview asked us to restore GPUI keyboard focus after a canvas click.
+    pending_keyboard_reclaim: bool,
+    /// True while a contenteditable text node in the webview is focused.
+    webview_text_editing: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -304,6 +309,22 @@ impl CanvasWorkspace {
 
         let viewport_bounds = Rc::new(Cell::new(Bounds::default()));
         let (web_ipc_sender, web_ipc_receiver) = async_channel::unbounded();
+        // Spawn before the webview builder borrows `window`.
+        let keyboard_reclaim_task = cx.spawn_in(window, async move |this, cx| {
+            loop {
+                cx.background_executor()
+                    .timer(Duration::from_millis(100))
+                    .await;
+                let keep_running = this
+                    .update_in(cx, |this, window, cx| {
+                        this.reclaim_keyboard_if_needed(window, cx);
+                    })
+                    .is_ok();
+                if !keep_running {
+                    break;
+                }
+            }
+        });
         let webview = cx.new({
             let viewport_bounds = viewport_bounds.clone();
             let web_ipc_sender = web_ipc_sender.clone();
@@ -319,6 +340,7 @@ impl CanvasWorkspace {
             viewport_bounds,
             webview,
             _web_ipc_task: None,
+            _keyboard_reclaim_task: Some(keyboard_reclaim_task),
             web_document_key: None,
             web_state_key: None,
             web_ready: false,
@@ -384,6 +406,8 @@ impl CanvasWorkspace {
             props_collapsed: HashSet::new(),
             active_breakpoint_id: None,
             focus_handle,
+            pending_keyboard_reclaim: false,
+            webview_text_editing: false,
         };
         workspace._web_ipc_task = Some(cx.spawn(async move |this, cx| {
             while let Ok(first_message) = web_ipc_receiver.recv().await {
@@ -413,6 +437,36 @@ impl CanvasWorkspace {
         workspace.pending_fit_all = true;
         workspace.fit_all_pages(cx);
         workspace
+    }
+
+    /// Restore GPUI + host keyboard focus after wry child interaction.
+    fn reclaim_keyboard_if_needed(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.webview_should_be_hidden() || self.webview_text_editing {
+            return;
+        }
+        let host_inputs_focused = self.layer_search_focused
+            || self.props_focus.is_some()
+            || self.command_edit.is_some()
+            || self.layer_rename.is_some()
+            || self.image_url_edit.is_some()
+            || self.shortcut_search_focused
+            || self.shortcut_recording.is_some();
+        if host_inputs_focused {
+            return;
+        }
+        self.pending_keyboard_reclaim = false;
+        self.webview.update(cx, |view, _| {
+            view.reclaim_host_keyboard();
+        });
+        // Canvas clicks FocusOut the GPUI X11 window (child webview steals input
+        // focus). Re-activate so subsequent host keybindings can run again after
+        // the user returns to chrome, and keep the workspace focus path warm.
+        if !window.is_window_active() {
+            window.activate_window();
+        }
+        if !self.focus_handle.is_focused(window) {
+            self.focus_handle.focus(window, cx);
+        }
     }
 
     fn shell_chrome_token(&self) -> ShellChromeToken {
@@ -498,6 +552,33 @@ impl CanvasWorkspace {
                 self.web_document_key = None;
                 self.web_state_key = None;
                 self.flush_pending_fit_all(cx);
+            }
+            // Canvas pointer hits the wry X11 child, so GPUI never sees the
+            // MouseDown. Ask for a keyboard reclaim on the next render frame.
+            "canvas-pointer" => {
+                if !self.webview_text_editing {
+                    self.pending_keyboard_reclaim = true;
+                    cx.notify();
+                }
+            }
+            "webview-editing" => {
+                let active = message
+                    .get("active")
+                    .and_then(|value| value.as_bool())
+                    .unwrap_or(false);
+                self.webview_text_editing = active;
+                if active {
+                    self.pending_keyboard_reclaim = false;
+                    self.webview.update(cx, |view, _| {
+                        view.focus_webview();
+                    });
+                } else {
+                    self.pending_keyboard_reclaim = true;
+                    self.webview.update(cx, |view, _| {
+                        view.reclaim_host_keyboard();
+                    });
+                    cx.notify();
+                }
             }
             "export-png" => {
                 let Some(path) = self.pending_png_export.take() else {
@@ -6269,7 +6350,10 @@ fn binding_for_action(action_id: &str, keystroke: &str) -> Option<KeyBinding> {
 }
 
 impl Render for CanvasWorkspace {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        if self.pending_keyboard_reclaim {
+            self.reclaim_keyboard_if_needed(window, cx);
+        }
         self.sync_web_canvas(cx);
         let theme = self.theme;
         let entity = cx.entity();

--- a/crates/ui/src/canvas/workspace.rs
+++ b/crates/ui/src/canvas/workspace.rs
@@ -30,6 +30,10 @@ use crate::canvas::properties::{
 };
 use crate::canvas::text_edit::{self, TextCursor, TextEditSession};
 use crate::canvas::web_canvas::CanvasWebView;
+#[cfg(target_os = "linux")]
+use crate::canvas::web_canvas::pump_linux_canvas;
+#[cfg(target_os = "linux")]
+use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 use crate::color_picker::ColorPickerPopover;
 use crate::context_menu::{
     action_id_at, first_action_index, move_highlight, ContextMenu, ContextMenuAction,
@@ -429,14 +433,30 @@ impl CanvasWorkspace {
         self.pending_keyboard_reclaim = false;
         self.webview.update(cx, |view, _| {
             view.reclaim_host_keyboard();
+            // Drop any DOM focus WebKit may have taken so it stops eating keys.
+            let _ = view.command(serde_json::json!({ "type": "blur-surface" }));
         });
-        // Always re-activate: after a wry child click the window may still report
-        // active while X keyboard focus is stuck on the embed container.
+        #[cfg(target_os = "linux")]
+        {
+            use gtk::gdk::prelude::*;
+            if let Some(display) = gtk::gdk::Display::default() {
+                if let Some(seat) = display.default_seat() {
+                    seat.ungrab();
+                }
+            }
+            // Clicking the wry child sends FocusOut(NotifyInferior) to the GPUI
+            // window. GPUI marks itself inactive; FocusIn goes to the unknown child
+            // XID and is dropped — so active stays false and keybindings die.
+            // Bounce X focus away and back so GPUI receives a real FocusIn.
+            force_x11_focus_reactivate(window);
+            pump_linux_canvas();
+        }
         window.activate_window();
         self.focus_handle.focus(window, cx);
         eprintln!(
-            "loora: host keyboard reclaim (focused={})",
-            self.focus_handle.is_focused(window)
+            "loora: host keyboard reclaim (focused={} active={})",
+            self.focus_handle.is_focused(window),
+            window.is_window_active()
         );
     }
 
@@ -535,6 +555,9 @@ impl CanvasWorkspace {
                         view.reclaim_host_keyboard();
                     });
                     self.pending_keyboard_reclaim = true;
+                    // Force a render so reclaim_keyboard_if_needed focuses Workspace
+                    // before the next key arrives (IPC chrome token may be unchanged).
+                    cx.notify();
                 }
             }
             "webview-editing" => {
@@ -549,6 +572,7 @@ impl CanvasWorkspace {
                     view.reclaim_host_keyboard();
                 });
                 self.pending_keyboard_reclaim = true;
+                cx.notify();
             }
             "export-png" => {
                 let Some(path) = self.pending_png_export.take() else {
@@ -1626,6 +1650,7 @@ impl CanvasWorkspace {
         match self.store.create(next_untitled_name(&self.files)) {
             Ok(doc) => {
                 eprintln!("loora: create_design → {}", doc.id);
+                let _ = std::io::Write::flush(&mut std::io::stderr());
                 self.load_document(doc, cx);
             }
             Err(err) => eprintln!("loora: create design failed: {err}"),
@@ -6331,6 +6356,47 @@ fn workspace_key_bindings(overrides: &HashMap<String, String>) -> Vec<KeyBinding
         }
     }
     bindings
+}
+
+/// Bounce X11 input focus so GPUI receives FocusIn after a wry child click.
+#[cfg(target_os = "linux")]
+fn force_x11_focus_reactivate(window: &Window) {
+    let Ok(handle) = HasWindowHandle::window_handle(window) else {
+        return;
+    };
+    let xid = match handle.as_raw() {
+        RawWindowHandle::Xlib(h) => h.window as x11_dl::xlib::Window,
+        RawWindowHandle::Xcb(h) => h.window.get() as x11_dl::xlib::Window,
+        _ => return,
+    };
+    let Ok(xlib) = x11_dl::xlib::Xlib::open() else {
+        return;
+    };
+    unsafe {
+        let display = (xlib.XOpenDisplay)(std::ptr::null());
+        if display.is_null() {
+            return;
+        }
+        // WebKit/GDK may hold a keyboard grab after child interaction.
+        (xlib.XUngrabKeyboard)(display, x11_dl::xlib::CurrentTime);
+        // PointerRoot briefly, then back to the GPUI toplevel.
+        (xlib.XSetInputFocus)(
+            display,
+            x11_dl::xlib::PointerRoot as x11_dl::xlib::Window,
+            x11_dl::xlib::RevertToPointerRoot,
+            x11_dl::xlib::CurrentTime,
+        );
+        (xlib.XFlush)(display);
+        (xlib.XSetInputFocus)(
+            display,
+            xid,
+            x11_dl::xlib::RevertToParent,
+            x11_dl::xlib::CurrentTime,
+        );
+        (xlib.XUngrabKeyboard)(display, x11_dl::xlib::CurrentTime);
+        (xlib.XFlush)(display);
+        (xlib.XCloseDisplay)(display);
+    }
 }
 
 fn binding_for_action(action_id: &str, keystroke: &str) -> Option<KeyBinding> {

--- a/crates/ui/src/canvas/workspace.rs
+++ b/crates/ui/src/canvas/workspace.rs
@@ -144,7 +144,6 @@ pub struct CanvasWorkspace {
     pub(crate) viewport_bounds: Rc<Cell<Bounds<Pixels>>>,
     webview: Entity<CanvasWebView>,
     _web_ipc_task: Option<Task<()>>,
-    _keyboard_reclaim_task: Option<Task<()>>,
     web_document_key: Option<WebDocumentKey>,
     web_state_key: Option<WebStateKey>,
     web_ready: bool,
@@ -309,22 +308,6 @@ impl CanvasWorkspace {
 
         let viewport_bounds = Rc::new(Cell::new(Bounds::default()));
         let (web_ipc_sender, web_ipc_receiver) = async_channel::unbounded();
-        // Spawn before the webview builder borrows `window`.
-        let keyboard_reclaim_task = cx.spawn_in(window, async move |this, cx| {
-            loop {
-                cx.background_executor()
-                    .timer(Duration::from_millis(100))
-                    .await;
-                let keep_running = this
-                    .update_in(cx, |this, window, cx| {
-                        this.reclaim_keyboard_if_needed(window, cx);
-                    })
-                    .is_ok();
-                if !keep_running {
-                    break;
-                }
-            }
-        });
         let webview = cx.new({
             let viewport_bounds = viewport_bounds.clone();
             let web_ipc_sender = web_ipc_sender.clone();
@@ -340,7 +323,6 @@ impl CanvasWorkspace {
             viewport_bounds,
             webview,
             _web_ipc_task: None,
-            _keyboard_reclaim_task: Some(keyboard_reclaim_task),
             web_document_key: None,
             web_state_key: None,
             web_ready: false,
@@ -439,28 +421,15 @@ impl CanvasWorkspace {
         workspace
     }
 
-    /// Restore GPUI + host keyboard focus after wry child interaction.
+    /// Restore GPUI keyboard focus after leaving the webview (chrome click / edit end).
     fn reclaim_keyboard_if_needed(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        if self.webview_should_be_hidden() || self.webview_text_editing {
-            return;
-        }
-        let host_inputs_focused = self.layer_search_focused
-            || self.props_focus.is_some()
-            || self.command_edit.is_some()
-            || self.layer_rename.is_some()
-            || self.image_url_edit.is_some()
-            || self.shortcut_search_focused
-            || self.shortcut_recording.is_some();
-        if host_inputs_focused {
+        if self.webview_text_editing {
             return;
         }
         self.pending_keyboard_reclaim = false;
         self.webview.update(cx, |view, _| {
             view.reclaim_host_keyboard();
         });
-        // Canvas clicks FocusOut the GPUI X11 window (child webview steals input
-        // focus). Re-activate so subsequent host keybindings can run again after
-        // the user returns to chrome, and keep the workspace focus path warm.
         if !window.is_window_active() {
             window.activate_window();
         }
@@ -553,12 +522,15 @@ impl CanvasWorkspace {
                 self.web_state_key = None;
                 self.flush_pending_fit_all(cx);
             }
-            // Canvas pointer hits the wry X11 child, so GPUI never sees the
-            // MouseDown. Ask for a keyboard reclaim on the next render frame.
+            // Canvas pointer hits the wry X11 child — give the webview keyboard so
+            // capture-phase JS shortcuts (Ctrl+N/R/…) receive keys. GPUI chrome
+            // clicks reclaim via the outside-bounds mouse handler + pending flag.
             "canvas-pointer" => {
                 if !self.webview_text_editing {
-                    self.pending_keyboard_reclaim = true;
-                    cx.notify();
+                    self.pending_keyboard_reclaim = false;
+                    self.webview.update(cx, |view, _| {
+                        view.focus_webview();
+                    });
                 }
             }
             "webview-editing" => {
@@ -573,11 +545,11 @@ impl CanvasWorkspace {
                         view.focus_webview();
                     });
                 } else {
-                    self.pending_keyboard_reclaim = true;
+                    // Still on the canvas after blur — keep webview keys for tools.
+                    self.pending_keyboard_reclaim = false;
                     self.webview.update(cx, |view, _| {
-                        view.reclaim_host_keyboard();
+                        view.focus_webview();
                     });
-                    cx.notify();
                 }
             }
             "export-png" => {

--- a/crates/ui/src/canvas/workspace.rs
+++ b/crates/ui/src/canvas/workspace.rs
@@ -194,6 +194,8 @@ pub struct CanvasWorkspace {
     files: Vec<DesignFileInfo>,
     saved_revision: u64,
     dirty: bool,
+    /// Last `save_now` failed; titlebar shows "Save failed" until a save succeeds.
+    save_failed: bool,
     _autosave_task: Option<Task<()>>,
     _image_tasks: Vec<Task<()>>,
     _caret_task: Option<Task<()>>,
@@ -362,6 +364,7 @@ impl CanvasWorkspace {
             files,
             saved_revision,
             dirty: false,
+            save_failed: false,
             _autosave_task: None,
             _image_tasks: Vec::new(),
             _caret_task: None,
@@ -427,7 +430,7 @@ impl CanvasWorkspace {
             command_open: self.command_open,
             command_query: self.command_query.clone(),
             command_index: self.command_index,
-            dirty: self.dirty,
+            dirty: self.dirty || self.save_failed,
             doc_name: self.document_name(),
             doc_id: self.document_id(),
             files_len: self.files.len(),
@@ -1724,9 +1727,11 @@ impl CanvasWorkspace {
     }
 
     fn load_document(&mut self, doc: loora_engine::Document, cx: &mut Context<Self>) {
+        self._autosave_task = None;
         self.engine.replace_document(doc);
         self.saved_revision = self.engine.revision();
         self.dirty = false;
+        self.save_failed = false;
         self.clear_selection();
         self.text_edit = None;
         self._caret_task = None;
@@ -1740,7 +1745,7 @@ impl CanvasWorkspace {
     }
 
     pub fn save_now(&mut self, cx: &mut Context<Self>) {
-        if self.engine.revision() == self.saved_revision && !self.dirty {
+        if self.engine.revision() == self.saved_revision && !self.dirty && !self.save_failed {
             return;
         }
         let document = self.engine.document().clone();
@@ -1749,18 +1754,27 @@ impl CanvasWorkspace {
                 let _ = self.store.set_active(&document.id);
                 self.saved_revision = self.engine.revision();
                 self.dirty = false;
+                self.save_failed = false;
                 self.refresh_files();
                 cx.notify();
             }
-            Err(err) => eprintln!("loora: save failed: {err}"),
+            Err(err) => {
+                eprintln!("loora: save failed: {err}");
+                self.save_failed = true;
+                self.dirty = true;
+                cx.notify();
+            }
         }
     }
 
     fn schedule_autosave(&mut self, cx: &mut Context<Self>) {
         if self.engine.revision() == self.saved_revision {
+            // Nothing to write; don't leave a stale dirty flag without a task.
+            self.dirty = false;
             return;
         }
         self.dirty = true;
+        self.save_failed = false;
         self._autosave_task = Some(cx.spawn(async move |this, cx| {
             cx.background_executor()
                 .timer(Duration::from_millis(450))
@@ -6229,10 +6243,11 @@ fn workspace_key_bindings(overrides: &HashMap<String, String>) -> Vec<KeyBinding
 fn binding_for_action(action_id: &str, keystroke: &str) -> Option<KeyBinding> {
     let context = Some("CanvasWorkspace");
     let binding = match action_id {
+        // App-level file/settings actions: work even when AppRoot (not canvas) is focused.
         "toggle_settings" => KeyBinding::new(keystroke, ToggleSettings, None),
-        "new_design" => KeyBinding::new(keystroke, NewDesign, context),
-        "open_designs" => KeyBinding::new(keystroke, ToggleFiles, context),
-        "save_design" => KeyBinding::new(keystroke, SaveDesign, context),
+        "new_design" => KeyBinding::new(keystroke, NewDesign, None),
+        "open_designs" => KeyBinding::new(keystroke, ToggleFiles, None),
+        "save_design" => KeyBinding::new(keystroke, SaveDesign, None),
         "undo" => KeyBinding::new(keystroke, Undo, context),
         "redo" => KeyBinding::new(keystroke, Redo, context),
         "zoom_in" => KeyBinding::new(keystroke, ZoomIn, context),
@@ -6306,6 +6321,7 @@ impl Render for CanvasWorkspace {
         let files = self.files.clone();
         let active_id = self.document_id();
         let dirty = self.dirty;
+        let save_failed = self.save_failed;
         let doc_name = self.document_name();
         let image_picker = self.image_picker.clone();
         let library_assets = image_picker
@@ -6536,8 +6552,18 @@ impl Render for CanvasWorkspace {
                                     .child(
                                         div()
                                             .text_size(px(11.))
-                                            .text_color(theme.muted)
-                                            .child(if dirty { "Autosaving…" } else { "Saved" }),
+                                            .text_color(if save_failed {
+                                                theme.red
+                                            } else {
+                                                theme.muted
+                                            })
+                                            .child(if save_failed {
+                                                "Save failed"
+                                            } else if dirty {
+                                                "Unsaved"
+                                            } else {
+                                                "Saved"
+                                            }),
                                     ),
                             ),
                     )

--- a/crates/ui/src/canvas/workspace.rs
+++ b/crates/ui/src/canvas/workspace.rs
@@ -522,15 +522,17 @@ impl CanvasWorkspace {
                 self.web_state_key = None;
                 self.flush_pending_fit_all(cx);
             }
-            // Canvas pointer hits the wry X11 child — give the webview keyboard so
-            // capture-phase JS shortcuts (Ctrl+N/R/…) receive keys. GPUI chrome
-            // clicks reclaim via the outside-bounds mouse handler + pending flag.
+            // Canvas pointer hits the wry X11 child. On Linux the child receives
+            // pointer events but X keyboard focus stays on the GPUI toplevel;
+            // wry's grab_focus() does not deliver keys to WebKit in this embed.
+            // Keep (or restore) host keyboard so AppRoot/Workspace shortcuts work.
             "canvas-pointer" => {
                 if !self.webview_text_editing {
-                    self.pending_keyboard_reclaim = false;
+                    eprintln!("loora: canvas-pointer → reclaim host keyboard");
                     self.webview.update(cx, |view, _| {
-                        view.focus_webview();
+                        view.reclaim_host_keyboard();
                     });
+                    self.pending_keyboard_reclaim = true;
                 }
             }
             "webview-editing" => {
@@ -539,18 +541,12 @@ impl CanvasWorkspace {
                     .and_then(|value| value.as_bool())
                     .unwrap_or(false);
                 self.webview_text_editing = active;
-                if active {
-                    self.pending_keyboard_reclaim = false;
-                    self.webview.update(cx, |view, _| {
-                        view.focus_webview();
-                    });
-                } else {
-                    // Still on the canvas after blur — keep webview keys for tools.
-                    self.pending_keyboard_reclaim = false;
-                    self.webview.update(cx, |view, _| {
-                        view.focus_webview();
-                    });
-                }
+                // Never grab_focus the child for editing — keys would vanish.
+                // Host keeps X focus; we forward keystrokes into contenteditable.
+                self.webview.update(cx, |view, _| {
+                    view.reclaim_host_keyboard();
+                });
+                self.pending_keyboard_reclaim = true;
             }
             "export-png" => {
                 let Some(path) = self.pending_png_export.take() else {
@@ -1627,10 +1623,46 @@ impl CanvasWorkspace {
         self.save_now(cx);
         match self.store.create(next_untitled_name(&self.files)) {
             Ok(doc) => {
+                eprintln!("loora: create_design → {}", doc.id);
                 self.load_document(doc, cx);
             }
             Err(err) => eprintln!("loora: create design failed: {err}"),
         }
+    }
+
+    /// Forward host keystrokes into the webview contenteditable. Needed on Linux
+    /// where the wry child never reliably receives X11 keyboard focus.
+    fn forward_key_to_webview_editor(&self, event: &KeyDownEvent, cx: &mut Context<Self>) {
+        let mods = &event.keystroke.modifiers;
+        let key = event.keystroke.key.as_str();
+        let action = match key {
+            "backspace" => Some("backspace"),
+            "delete" => Some("delete"),
+            "enter" => Some("enter"),
+            "escape" => Some("escape"),
+            "left" => Some("left"),
+            "right" => Some("right"),
+            "up" => Some("up"),
+            "down" => Some("down"),
+            "home" => Some("home"),
+            "end" => Some("end"),
+            _ => None,
+        };
+        let payload = if let Some(action) = action {
+            serde_json::json!({
+                "type": "inject-key",
+                "action": action,
+                "shift": mods.shift,
+            })
+        } else if let Some(ch) = event.keystroke.key_char.as_deref() {
+            if mods.control || mods.platform || mods.alt || ch.is_empty() {
+                return;
+            }
+            serde_json::json!({ "type": "inject-key", "text": ch })
+        } else {
+            return;
+        };
+        let _ = self.webview.update(cx, |view, _| view.command(payload));
     }
 
     pub fn open_design(&mut self, id: &str, cx: &mut Context<Self>) {
@@ -5404,6 +5436,12 @@ impl CanvasWorkspace {
             return;
         }
 
+        if self.webview_text_editing {
+            self.forward_key_to_webview_editor(event, cx);
+            cx.stop_propagation();
+            return;
+        }
+
         if self.context_menu.is_some() {
             self.on_context_menu_key_down(event, cx);
             return;
@@ -6411,7 +6449,11 @@ impl Render for CanvasWorkspace {
             .size_full()
             .bg(theme.window_fill())
             .text_color(theme.foreground)
-            .key_context("CanvasWorkspace")
+            .key_context(if self.webview_text_editing {
+                "WebviewTextEditing"
+            } else {
+                "CanvasWorkspace"
+            })
             .track_focus(&self.focus_handle)
             .on_action(cx.listener(Self::undo))
             .on_action(cx.listener(Self::redo))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ctrl+N / tool keys stop working after clicking the wry canvas on Linux because the X11 WebKit child can leave GPUI without KeyPress delivery (`surface.focus` / `focus_parent` / FocusOut NotifyInferior).

### Approach
- Stop `surface.focus()` and Linux `focus_parent()` from stealing host keys.
- On `canvas-pointer`, reclaim host keyboard (ungrab, FocusIn bounce, focus Workspace).
- Disable WebKit `can_focus` + X11 `InputHint` on the embed window.
- **X11 key grab** on the Loora window tree for Ctrl+N/O/S/K and tool keys (`r/v/h/f/t/i`), forwarded over canvas IPC as `command` — this is what makes canvas shortcuts reliable when GPUI misses KeyPress.
- Forward contenteditable typing via `inject-key` while editing.
- Rebased onto merged #15 via merge of `origin/loora-rs` (`156fa2b`).

### Merge conflicts (resolved)
After fetching `loora-rs` (#15 landed), only `crates/ui/src/canvas/web_canvas.rs` conflicted (4 hunks). All were **simple / clear supersede**:
1. zoomChip `pointerdown` — keep `preventDefault` + `stopPropagation` (host focus)
2. comment wording — keep #16 capture-phase note
3. window `keydown` — keep #16 capture-phase full shortcut map (`KeyN`/`code`, tools, `stopPropagation`, `true`); drops #15’s narrower bubble-only `n`/`o`/`s` listener
4. unit tests — keep #16 capture-phase assertions

No conflicting product intents beyond #16 intentionally replacing #15’s interim JS shortcut approach for the same Ctrl+N problem. CTA/`app_root` content was identical to merged #15.

### Validation
- `cargo test -p loora-ui webview_` — 11 passed
- Grok 4.5 GUI smoke (pre-merge tip): canvas Ctrl+N/O, `r`/`t` PASS

[Ctrl+N → Untitled 88](https://cursor.com/agents/bc-3040b235-af69-45b2-b135-dfa455542015/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsmoke-ctrl-n-untitled-88.webp)
[Ctrl+N → Untitled 89](https://cursor.com/agents/bc-3040b235-af69-45b2-b135-dfa455542015/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsmoke-ctrl-n-untitled-89.webp)
[Ctrl+O design browser](https://cursor.com/agents/bc-3040b235-af69-45b2-b135-dfa455542015/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsmoke-ctrl-o-dialog.webp)
[Rectangle tool after r](https://cursor.com/agents/bc-3040b235-af69-45b2-b135-dfa455542015/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsmoke-tool-r.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3040b235-af69-45b2-b135-dfa455542015?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3040b235-af69-45b2-b135-dfa455542015&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

